### PR TITLE
Test pushing with the secrets more recently defined

### DIFF
--- a/.github/workflows/on-merge.yaml
+++ b/.github/workflows/on-merge.yaml
@@ -43,6 +43,4 @@ jobs:
       - name: Publish to Artifactory
         shell: bash
         run: |
-          export UV_INDEX_ARTIFACTORY_USERNAME=${{ vars.EVO_ARTIFACTORY_USER }}
-          export UV_INDEX_ARTIFACTORY_PASSWORD=${{ secrets.EVO_ARTIFACTORY_TOKEN }}
-          uv publish --index artifactory
+          uv publish --index artifactory --username ${{ vars.EVO_ARTIFACTORY_USER }} --password ${{ secrets.EVO_ARTIFACTORY_TOKEN }}

--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -57,8 +57,3 @@ jobs:
         with:
           path: ./dist
           name: Build-${{ env.PACKAGE_VERSION }}
-
-      - name: Publish to Artifactory
-        shell: bash
-        run: |
-          uv publish --index artifactory --username ${{ vars.EVO_ARTIFACTORY_USER }} --password ${{ secrets.EVO_ARTIFACTORY_TOKEN }}


### PR DESCRIPTION
Publish failed with missing credentials - https://github.com/seequent/evo-open-data-converters/actions/runs/13848597038/job/38751788376

Turns out it needed an explicitly passed username and password rather than the exported variables. Fixed that.
Tested by uploading a dev build to Artifactory.

![image](https://github.com/user-attachments/assets/41b81a1b-8edc-40a7-b6b6-dbd93c8a285a)

