### PR TITLE
Add note to readme explaining that omf2 must be installed from source first

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,11 @@ The existing data converters can be used without modification or used as a templ
 
 ## Installation
 
+**Note:** This project depends on `omf2`, which is not available in PyPI yet. You must install it from source before you can use this project.
+
 ```
+pip install -e "git+https://github.com/gmggroup/omf-rust.git#egg=omf2&subdirectory=omf-python"
+
 pip install evo-data-converters
 ```
 


### PR DESCRIPTION
<!--
Thank you for taking the time to make a pull request.

Please review our [contribution guide](https://github.com/SeequentEvo/evo-data-converters/blob/main/CONTRIBUTING.md) and our
[code of conduct](https://github.com/SeequentEvo/evo-data-converters/blob/main/CONTRIBUTING.md) before opening your first
pull request.

By making a pull request, you confirm you agree to our [Contributor License Agreement (CLA).](https://gist.github.com/imodeljs-admin/9a071844d3a8d420092b5cf360e978ca)
-->

## Description

`omf2` isn't available in PyPI yet (see https://github.com/gmggroup/omf-rust/issues/32 for tracking). This PR adds instructions to the readme for installing `omf2` from source before installing `evo-data-converters`.

## Checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have read the contributing guide and the code of conduct
