### PR TITLE
Fix for relative link replacement in PyPI

### DIFF
--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -59,7 +59,7 @@ New converters can be created to support additional data file types.
 
 ### Working on data converters
 
-To work on your local version of the data converters module, first follow the directions in [Setting up your environment.](../README.md)
+To work on your local version of the data converters module, first follow the directions in [Setting up your environment.](https://github.com/seequentevo/evo-data-converters/blob/main/README.md)
 
 In the root directory of the project run:
 

--- a/packages/common/pyproject.toml
+++ b/packages/common/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "evo-data-converters-common"
 description = "Python framework for building data converters between common geoscience data formats"
-version = "0.1.1"
+version = "0.1.2"
 requires-python = ">=3.10"
 license-files = ["LICENSE.md"]
 dynamic = ["readme"]
@@ -51,4 +51,4 @@ path = "README.md"
 # Literal TOML strings (single quotes) need no escaping of backslashes.
 # Converts relative links to absolute links in PyPI
 pattern = '\[(.+?)\]\(((?!https?://)\S+?)\)'
-replacement = '[\1](https://github.com/SeequentEvo/evo-data-converters/tree/main/packages/$HFPR_PACKAGE_NAME/\g<2>)'
+replacement = '[\1](https://github.com/SeequentEvo/evo-data-converters/tree/main/packages/common/\g<2>)'

--- a/packages/gocad/pyproject.toml
+++ b/packages/gocad/pyproject.toml
@@ -41,4 +41,4 @@ path = "README.md"
 # Literal TOML strings (single quotes) need no escaping of backslashes.
 # Converts relative links to absolute links in PyPI
 pattern = '\[(.+?)\]\(((?!https?://)\S+?)\)'
-replacement = '[\1](https://github.com/SeequentEvo/evo-data-converters/tree/main/packages/$HFPR_PACKAGE_NAME/\g<2>)'
+replacement = '[\1](https://github.com/SeequentEvo/evo-data-converters/tree/main/packages/gocad/\g<2>)'

--- a/packages/omf/pyproject.toml
+++ b/packages/omf/pyproject.toml
@@ -44,4 +44,4 @@ path = "README.md"
 # Literal TOML strings (single quotes) need no escaping of backslashes.
 # Converts relative links to absolute links in PyPI
 pattern = '\[(.+?)\]\(((?!https?://)\S+?)\)'
-replacement = '[\1](https://github.com/SeequentEvo/evo-data-converters/tree/main/packages/$HFPR_PACKAGE_NAME/\g<2>)'
+replacement = '[\1](https://github.com/SeequentEvo/evo-data-converters/tree/main/packages/omf/\g<2>)'

--- a/packages/resqml/pyproject.toml
+++ b/packages/resqml/pyproject.toml
@@ -43,4 +43,4 @@ path = "README.md"
 # Literal TOML strings (single quotes) need no escaping of backslashes.
 # Converts relative links to absolute links in PyPI
 pattern = '\[(.+?)\]\(((?!https?://)\S+?)\)'
-replacement = '[\1](https://github.com/SeequentEvo/evo-data-converters/tree/main/packages/$HFPR_PACKAGE_NAME/\g<2>)'
+replacement = '[\1](https://github.com/SeequentEvo/evo-data-converters/tree/main/packages/resqml/\g<2>)'

--- a/packages/ubc/pyproject.toml
+++ b/packages/ubc/pyproject.toml
@@ -41,4 +41,4 @@ path = "README.md"
 # Literal TOML strings (single quotes) need no escaping of backslashes.
 # Converts relative links to absolute links in PyPI
 pattern = '\[(.+?)\]\(((?!https?://)\S+?)\)'
-replacement = '[\1](https://github.com/SeequentEvo/evo-data-converters/tree/main/packages/$HFPR_PACKAGE_NAME/\g<2>)'
+replacement = '[\1](https://github.com/SeequentEvo/evo-data-converters/tree/main/packages/ubc/\g<2>)'

--- a/packages/vtk/pyproject.toml
+++ b/packages/vtk/pyproject.toml
@@ -42,4 +42,4 @@ path = "README.md"
 # Literal TOML strings (single quotes) need no escaping of backslashes.
 # Converts relative links to absolute links in PyPI
 pattern = '\[(.+?)\]\(((?!https?://)\S+?)\)'
-replacement = '[\1](https://github.com/SeequentEvo/evo-data-converters/tree/main/packages/$HFPR_PACKAGE_NAME/\g<2>)'
+replacement = '[\1](https://github.com/SeequentEvo/evo-data-converters/tree/main/packages/vtk/\g<2>)'


### PR DESCRIPTION
The package name isn't the folder name, so I've replaced the regex replacement with the folder name.

