### PR TITLE
Release workflows now only run tests for the package they are releasing, and the common package

### DIFF
--- a/.github/workflows/publish-common.yaml
+++ b/.github/workflows/publish-common.yaml
@@ -16,7 +16,27 @@ env:
 jobs:
   run-tests:
     if: startsWith(github.event.release.tag_name, 'evo-data-converters-common@')
-    uses: ./.github/workflows/run-all-tests.yaml
+    name: Test
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - windows-latest
+          - ubuntu-latest
+          - macos-latest
+        python-version:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+        package:
+          - common
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/testing
+        with:
+          PACKAGE: ${{ matrix.package }}
+          PYTHON_VERSION: ${{ matrix.python-version }}
 
   build-and-publish:
     name: Build and publish package

--- a/.github/workflows/publish-gocad.yaml
+++ b/.github/workflows/publish-gocad.yaml
@@ -16,7 +16,28 @@ env:
 jobs:
   run-tests:
     if: startsWith(github.event.release.tag_name, 'evo-data-converters-gocad@')
-    uses: ./.github/workflows/run-all-tests.yaml
+    name: Test
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - windows-latest
+          - ubuntu-latest
+          - macos-latest
+        python-version:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+        package:
+          - common
+          - gocad
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/testing
+        with:
+          PACKAGE: ${{ matrix.package }}
+          PYTHON_VERSION: ${{ matrix.python-version }}
 
   build-and-publish:
     name: Build and publish package

--- a/.github/workflows/publish-omf.yaml
+++ b/.github/workflows/publish-omf.yaml
@@ -16,7 +16,28 @@ env:
 jobs:
   run-tests:
     if: startsWith(github.event.release.tag_name, 'evo-data-converters-omf@')
-    uses: ./.github/workflows/run-all-tests.yaml
+    name: Test
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - windows-latest
+          - ubuntu-latest
+          - macos-latest
+        python-version:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+        package:
+          - common
+          - omf
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/testing
+        with:
+          PACKAGE: ${{ matrix.package }}
+          PYTHON_VERSION: ${{ matrix.python-version }}
 
   build-and-publish:
     name: Build and publish package

--- a/.github/workflows/publish-resqml.yaml
+++ b/.github/workflows/publish-resqml.yaml
@@ -16,7 +16,28 @@ env:
 jobs:
   run-tests:
     if: startsWith(github.event.release.tag_name, 'evo-data-converters-resqml@')
-    uses: ./.github/workflows/run-all-tests.yaml
+    name: Test
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - windows-latest
+          - ubuntu-latest
+          - macos-latest
+        python-version:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+        package:
+          - common
+          - resqml
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/testing
+        with:
+          PACKAGE: ${{ matrix.package }}
+          PYTHON_VERSION: ${{ matrix.python-version }}
 
   build-and-publish:
     name: Build and publish package

--- a/.github/workflows/publish-ubc.yaml
+++ b/.github/workflows/publish-ubc.yaml
@@ -16,7 +16,28 @@ env:
 jobs:
   run-tests:
     if: startsWith(github.event.release.tag_name, 'evo-data-converters-ubc@')
-    uses: ./.github/workflows/run-all-tests.yaml
+    name: Test
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - windows-latest
+          - ubuntu-latest
+          - macos-latest
+        python-version:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+        package:
+          - common
+          - ubc
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/testing
+        with:
+          PACKAGE: ${{ matrix.package }}
+          PYTHON_VERSION: ${{ matrix.python-version }}
 
   build-and-publish:
     name: Build and publish package

--- a/.github/workflows/publish-vtk.yaml
+++ b/.github/workflows/publish-vtk.yaml
@@ -16,7 +16,28 @@ env:
 jobs:
   run-tests:
     if: startsWith(github.event.release.tag_name, 'evo-data-converters-vtk@')
-    uses: ./.github/workflows/run-all-tests.yaml
+    name: Test
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - windows-latest
+          - ubuntu-latest
+          - macos-latest
+        python-version:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+        package:
+          - common
+          - vtk
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/testing
+        with:
+          PACKAGE: ${{ matrix.package }}
+          PYTHON_VERSION: ${{ matrix.python-version }}
 
   build-and-publish:
     name: Build and publish package


### PR DESCRIPTION
<!--
Thank you for taking the time to make a pull request.

Please review our [contribution guide](https://github.com/SeequentEvo/evo-data-converters/blob/main/CONTRIBUTING.md) and our
[code of conduct](https://github.com/SeequentEvo/evo-data-converters/blob/main/CONTRIBUTING.md) before opening your first
pull request.

By making a pull request, you confirm you agree to our [Contributor License Agreement (CLA).](https://gist.github.com/imodeljs-admin/9a071844d3a8d420092b5cf360e978ca)
-->

## Description

Fixes #50

If we release GOCAD and the OMF tests fail, it blocks the GOCAD release pipeline, even though there are no changes to make to fix the GOCAD module.

Now we just run the package we're releasing and the common package. Pull requests will continue to run all tests, for now.

## Checklist

- [x] I have read the contributing guide and the code of conduct

