### PR TITLE
Gitleaks configuration

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,13 @@
+title = "Seequent EVO data converters rules"
+[extend]
+useDefault = true
+
+[[rules]]
+id = "no-user-paths"
+description = "Detect personal usernames."
+regex = '''/(home|Users)/([a-z0-9]+)/'''
+
+[[rules]]
+id = "seequent-evo-token"
+description = "Detect Seequent Evo token patterns"
+regex = '''((?:service|spa|webapp)-[A-z0-9]{12,})\b'''

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,7 @@ repos:
     hooks:
       - id: nbstripout
         name: Strip outputs from Jupyter notebooks
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.24.2
+    hooks:
+      - id: gitleaks


### PR DESCRIPTION
## Description

This PR adds a [pre-commit](https://pre-commit.com/) hook using [Gitleaks](https://github.com/gitleaks/gitleaks) to scan for secrets before committing.

Two example pattern rules are in this draft PR:

- Prevent committing personal details (homedir paths)
- Prevent committing Seequent Evo patterns

These are example patterns for consideration.

Github Advanced Security includes secret scanning applied once changes are pushed; this check would provide an additional check before the changes are committed and pushed.

## Checklist

- [x] I have read the contributing guide and the code of conduct
