### PR TITLE
Publish new version if object exists at same path

### DIFF
--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -11,7 +11,7 @@
 
 ## Evo
 
-Evo is a unified platform for geoscience teams. It enables access, connection, computation, and management of subsurface data. This empowers better decision-making, simplified collaboration, and accelerated innovation. Evo is built on open APIs, allowing developers to build custom integrations and applications. Our open schemas, code examples, and SDK are available for the community to use and extend. 
+Evo is a unified platform for geoscience teams. It enables access, connection, computation, and management of subsurface data. This empowers better decision-making, simplified collaboration, and accelerated innovation. Evo is built on open APIs, allowing developers to build custom integrations and applications. Our open schemas, code examples, and SDK are available for the community to use and extend.
 
 Evo is powered by Seequent, a Bentley organisation.
 
@@ -181,6 +181,7 @@ def convert_yourfiletype(
     evo_workspace_metadata: Optional[EvoWorkspaceMetadata] = None,
     service_manager_widget: Optional["ServiceManagerWidget"] = None,
     upload_path: str = "",
+    overwrite_existing_objects: bool = False
 ) -> list[ObjectMetadata]:
     geoscience_objects = []
 
@@ -205,7 +206,7 @@ def convert_yourfiletype(
 
     # Publish the found geoscience objects to Evo
     objects_metadata = publish_geoscience_objects(
-        geoscience_objects, object_service_client, data_client, upload_path
+        geoscience_objects, object_service_client, data_client, upload_path, overwrite_existing_objects
     )
 
     # Return the publishing response

--- a/packages/common/tests/test_publish_geoscience_objects.py
+++ b/packages/common/tests/test_publish_geoscience_objects.py
@@ -12,6 +12,7 @@
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, MagicMock, Mock, call, patch
 
+from evo.common.exceptions import NotFoundException
 from evo.data_converters.common.publish import publish_geoscience_object, publish_geoscience_objects
 
 
@@ -22,6 +23,7 @@ class TestPublishGeoscienceObjects(IsolatedAsyncioTestCase):
 
         self.test_object = Mock()
         self.test_object.as_dict.return_value = {"test": "data"}
+        self.test_object.uuid = None  # Initialize uuid attribute
         self.test_objects = [self.test_object, self.test_object]
 
     @patch("evo.data_converters.common.publish.publish_geoscience_object")
@@ -38,6 +40,7 @@ class TestPublishGeoscienceObjects(IsolatedAsyncioTestCase):
             object_service_client=self.mock_object_service_client,
             data_client=self.mock_data_client,
             path_prefix="test",
+            overwrite_existing_objects=False,
         )
 
         self.assertEqual(len(objects_metadata), 2)
@@ -48,8 +51,12 @@ class TestPublishGeoscienceObjects(IsolatedAsyncioTestCase):
 
         mock_publish_geoscience_object.assert_has_calls(
             [
-                call("test/mock_1.json", self.test_object, self.mock_object_service_client, self.mock_data_client),
-                call("test/mock_2.json", self.test_object, self.mock_object_service_client, self.mock_data_client),
+                call(
+                    "test/mock_1.json", self.test_object, self.mock_object_service_client, self.mock_data_client, False
+                ),
+                call(
+                    "test/mock_2.json", self.test_object, self.mock_object_service_client, self.mock_data_client, False
+                ),
             ]
         )
 
@@ -60,23 +67,70 @@ class TestPublishGeoscienceObjects(IsolatedAsyncioTestCase):
         self.assertEqual(objects_metadata, [])
         mock_publish_geoscience_object.assert_not_called()
 
-    async def test_publish_geoscience_object(self) -> None:
+    async def test_publish_geoscience_object_creates_new_object(self) -> None:
+        """Test publishing when object doesn't exist (404 NotFound)"""
         object_path = "test/object_1.json"
         expected_metadata = Mock()
 
+        # Reset uuid to None
+        self.test_object.uuid = None
+
         self.mock_data_client.upload_referenced_data = AsyncMock()
         self.mock_object_service_client.create_geoscience_object = AsyncMock(return_value=expected_metadata)
+        self.mock_object_service_client.download_object_by_path = AsyncMock(
+            side_effect=NotFoundException(404, "Not found", None, None)
+        )
 
         object_metadata = await publish_geoscience_object(
             path=object_path,
             object_model=self.test_object,
             object_service_client=self.mock_object_service_client,
             data_client=self.mock_data_client,
+            overwrite_existing_object=False,
         )
 
         assert object_metadata == expected_metadata
 
+        # Verify the correct methods were called
+        self.mock_object_service_client.download_object_by_path.assert_awaited_once_with(object_path)
         self.mock_data_client.upload_referenced_data.assert_awaited_once_with(self.test_object.as_dict())
         self.mock_object_service_client.create_geoscience_object.assert_awaited_once_with(
             object_path, self.test_object.as_dict()
         )
+
+        # Ensure uuid was not set (should still be None)
+        assert self.test_object.uuid is None
+
+    async def test_publish_geoscience_object_updates_existing_object(self) -> None:
+        """Test publishing when object exists and overwrite_existing_object is True"""
+        object_path = "test/object_1.json"
+        expected_metadata = Mock()
+        existing_uuid = "existing-uuid-123"
+
+        self.test_object.uuid = None
+
+        existing_object = Mock()
+        existing_object.metadata.id = existing_uuid
+
+        self.mock_data_client.upload_referenced_data = AsyncMock()
+        self.mock_object_service_client.update_geoscience_object = AsyncMock(return_value=expected_metadata)
+        self.mock_object_service_client.download_object_by_path = AsyncMock(return_value=existing_object)
+
+        object_metadata = await publish_geoscience_object(
+            path=object_path,
+            object_model=self.test_object,
+            object_service_client=self.mock_object_service_client,
+            data_client=self.mock_data_client,
+            overwrite_existing_object=True,
+        )
+
+        assert object_metadata == expected_metadata
+
+        self.mock_object_service_client.download_object_by_path.assert_awaited_once_with(object_path)
+
+        assert self.test_object.uuid == existing_uuid
+
+        self.mock_data_client.upload_referenced_data.assert_awaited_once_with(self.test_object.as_dict())
+        self.mock_object_service_client.update_geoscience_object.assert_awaited_once_with(self.test_object.as_dict())
+
+        self.mock_object_service_client.create_geoscience_object.assert_not_called()

--- a/packages/duf/src/evo/data_converters/duf/importer/duf_to_evo.py
+++ b/packages/duf/src/evo/data_converters/duf/importer/duf_to_evo.py
@@ -124,6 +124,7 @@ def convert_duf(
     tags: Optional[dict[str, str]] = None,
     combine_objects_in_layers: bool = False,
     upload_path: str = "",
+    overwrite_existing_objects: bool = False,
 ) -> list[BaseSpatialDataProperties_V1_0_1 | ObjectMetadata]:
     """Converts a DUF file into Geoscience Objects.
 
@@ -176,7 +177,7 @@ def convert_duf(
     if publish_objects:
         logger.debug("Publishing Geoscience Objects")
         objects_metadata = publish_geoscience_objects(
-            geoscience_objects, object_service_client, data_client, upload_path
+            geoscience_objects, object_service_client, data_client, upload_path, overwrite_existing_objects
         )
 
     return objects_metadata if objects_metadata else geoscience_objects

--- a/packages/gocad/src/evo/data_converters/gocad/importer/gocad_to_evo.py
+++ b/packages/gocad/src/evo/data_converters/gocad/importer/gocad_to_evo.py
@@ -35,6 +35,7 @@ def convert_gocad(
     service_manager_widget: Optional["ServiceManagerWidget"] = None,
     tags: Optional[dict[str, str]] = None,
     upload_path: str = "",
+    overwrite_existing_objects: bool = False,
 ) -> list[BaseSpatialDataProperties_V1_0_1 | ObjectMetadata]:
     """Converts a GOCAD files into Geoscience Objects.
 
@@ -74,7 +75,7 @@ def convert_gocad(
     if publish_objects:
         logger.debug("Publishing Geoscience Objects")
         objects_metadata = publish_geoscience_objects(
-            geoscience_objects, object_service_client, data_client, upload_path
+            geoscience_objects, object_service_client, data_client, upload_path, overwrite_existing_objects
         )
 
     return objects_metadata if objects_metadata else geoscience_objects

--- a/packages/omf/samples/convert-omf/convert-omf.ipynb
+++ b/packages/omf/samples/convert-omf/convert-omf.ipynb
@@ -38,7 +38,7 @@
     "\n",
     "You may also specify tags to add to the created Geoscience objects.\n",
     "\n",
-    "Then we call `convert_omf`, passing it the OMF file path, EPSG code, the service manager widget from above and finally a path we want the published objects to appear under.\n",
+    "Then we call `convert_omf`, passing it the OMF file path, EPSG code, the service manager widget from above, a path we want the published objects to appear under and finally whether we want existing objects to be overwritten.\n",
     "\n",
     "Then we loop over the results from the `convert_omf` function, printing out each object that was published to Evo.\n",
     "\n",
@@ -62,7 +62,12 @@
     "tags = {\"TagName\": \"Tag value\"}\n",
     "\n",
     "objects_metadata = convert_omf(\n",
-    "    filepath=omf_file, epsg_code=epsg_code, service_manager_widget=manager, tags=tags, upload_path=\"notebook\"\n",
+    "    filepath=omf_file,\n",
+    "    epsg_code=epsg_code,\n",
+    "    service_manager_widget=manager,\n",
+    "    tags=tags,\n",
+    "    upload_path=\"notebook\",\n",
+    "    overwrite_existing_objects=False,\n",
     ")\n",
     "\n",
     "print()\n",
@@ -75,7 +80,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "venv",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -89,7 +94,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.15"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/packages/omf/samples/convert-omf/publish-omf-script.py
+++ b/packages/omf/samples/convert-omf/publish-omf-script.py
@@ -28,6 +28,10 @@ parser.add_argument(
 parser.add_argument("--upload-path", help="Path to upload objects to.")
 
 parser.add_argument(
+    "--overwrite-existing-objects", action="store_true", default=False, help="Overwrite existing objects"
+)
+
+parser.add_argument(
     "--cache-dir",
     help="Local directory to store processed files. If it doesn't exist it will be created. Defaults to a temporary directory if not provided.",
 )
@@ -102,6 +106,7 @@ results = convert_omf(
     epsg_code=args.epsg_code,
     tags=tags,
     upload_path=args.upload_path,
+    overwrite_existing_objects=args.overwrite_existing_objects,
 )
 
 # Results will either be a list of BaseSpatialDataProperties_V1_0_1 if not published, or a list of ObjectMetadata if they were published

--- a/packages/omf/src/evo/data_converters/omf/importer/omf_to_evo.py
+++ b/packages/omf/src/evo/data_converters/omf/importer/omf_to_evo.py
@@ -42,6 +42,7 @@ def convert_omf(
     service_manager_widget: Optional["ServiceManagerWidget"] = None,
     tags: Optional[dict[str, str]] = None,
     upload_path: str = "",
+    overwrite_existing_objects: bool = False,
 ) -> list[BaseSpatialDataProperties_V1_0_1 | ObjectMetadata | dict]:
     """Converts an OMF file into Geoscience Objects.
 
@@ -128,7 +129,7 @@ def convert_omf(
     if publish_objects:
         logger.debug("Publishing Geoscience Objects")
         objects_metadata = publish_geoscience_objects(
-            geoscience_objects, object_service_client, data_client, upload_path
+            geoscience_objects, object_service_client, data_client, upload_path, overwrite_existing_objects
         )
 
     return objects_metadata + block_models if objects_metadata else geoscience_objects + block_models

--- a/packages/resqml/src/evo/data_converters/resqml/importer/resqml_to_evo.py
+++ b/packages/resqml/src/evo/data_converters/resqml/importer/resqml_to_evo.py
@@ -52,6 +52,7 @@ def convert_resqml(
     tags: Optional[dict[str, str]] = None,
     upload_path: str = "",
     options: RESQMLConversionOptions = RESQMLConversionOptions(),
+    overwrite_existing_objects: bool = False,
 ) -> list[BaseSpatialDataProperties_V1_0_1 | ObjectMetadata]:
     """Converts a RESQML file into Evo Geoscience Objects.
     service_manager_widget: ServiceManagerWidget = None,
@@ -114,7 +115,7 @@ def convert_resqml(
     if publish_objects:
         logger.debug("Publishing Geoscience Objects")
         objects_metadata = publish_geoscience_objects(
-            geoscience_objects, object_service_client, data_client, upload_path
+            geoscience_objects, object_service_client, data_client, upload_path, overwrite_existing_objects
         )
 
     return objects_metadata if objects_metadata else geoscience_objects

--- a/packages/ubc/src/evo/data_converters/ubc/importer/ubc_to_evo.py
+++ b/packages/ubc/src/evo/data_converters/ubc/importer/ubc_to_evo.py
@@ -35,6 +35,7 @@ def convert_ubc(
     service_manager_widget: Optional["ServiceManagerWidget"] = None,
     tags: Optional[dict[str, str]] = None,
     upload_path: str = "",
+    overwrite_existing_objects: bool = False,
 ) -> list[BaseSpatialDataProperties_V1_0_1 | ObjectMetadata]:
     """Converts a UBC files into Geoscience Objects.
 
@@ -74,7 +75,7 @@ def convert_ubc(
     if publish_objects:
         logger.debug("Publishing Geoscience Objects")
         objects_metadata = publish_geoscience_objects(
-            geoscience_objects, object_service_client, data_client, upload_path
+            geoscience_objects, object_service_client, data_client, upload_path, overwrite_existing_objects
         )
 
     return objects_metadata if objects_metadata else geoscience_objects

--- a/packages/ubc/tests/importers/test_ubc_to_evo.py
+++ b/packages/ubc/tests/importers/test_ubc_to_evo.py
@@ -50,6 +50,7 @@ def test_convert_ubc_success() -> None:
             mock_create_client.return_value[0],
             mock_create_client.return_value[1],
             upload_path,
+            False,
         )
 
 

--- a/packages/vtk/src/evo/data_converters/vtk/importer/vtk_to_evo.py
+++ b/packages/vtk/src/evo/data_converters/vtk/importer/vtk_to_evo.py
@@ -81,6 +81,7 @@ def convert_vtk(
     service_manager_widget: Optional["ServiceManagerWidget"] = None,
     tags: Optional[dict[str, str]] = None,
     upload_path: str = "",
+    overwrite_existing_objects: bool = False,
 ) -> list[BaseSpatialDataProperties_V1_0_1 | ObjectMetadata]:
     """Converts an VTK file into Geoscience Objects.
 
@@ -145,7 +146,7 @@ def convert_vtk(
     if publish_objects:
         logger.debug("Publishing Geoscience Objects")
         objects_metadata = publish_geoscience_objects(
-            geoscience_objects, object_service_client, data_client, upload_path
+            geoscience_objects, object_service_client, data_client, upload_path, overwrite_existing_objects
         )
 
     return objects_metadata if objects_metadata else geoscience_objects


### PR DESCRIPTION
## Description

Adds a flag to the `convert_*` functions: `overwrite_existing_objects=False` which gets passed down to `publish_geoscience_objects()` and `publish_geoscience_object()`.

On publishing a geoscience object in `packages/common/src/evo/data_converters/common/publish.py`

- Looks for an existing object at the same path
- If an existing object is found and `overwrite_existing_objects=True` then a new version of the same object is created
- If an existing object is found and `overwrite_existing_objects=False` then an error is raised about the UUID needing to be unique
- If there is no existing object at the path, then a new object is created

## Checklist

- [x] I have read the contributing guide and the code of conduct
