### PR TITLE
Allow extracting GOCAD data as non-geoscience objects

### DIFF
--- a/packages/common/src/evo/data_converters/common/grid_data.py
+++ b/packages/common/src/evo/data_converters/common/grid_data.py
@@ -50,7 +50,7 @@ class RegularGridData(BaseGridData):
     origin: list[float] - The coordinates of the origin [x,y,z]
     size: list[int] - The size of the entire grid [grid_size_x, grid_size_y, grid_size_z]
     rotation: numpy NDArray[numpy float] - Orientation of the grid [dip_azimuth, dip, pitch]
-    bounding_box: list[float] | None - Bounding box of the spatial data
+    bounding_box: list[float] | None - Bounding box of the spatial data [min_x, max_x, min_y, max_y, min_z, max_z]
     mask: numpy NDArray[numpy bool] | None - Indicates which cells have values
     cell_attributes: dict[str, numpy NDArray] | None - Attributes associated with the cells
     vertex_attributes: dict[str, numpy NDArray] | None - Attributes associated with the vertices

--- a/packages/gocad/src/evo/data_converters/gocad/importer/__init__.py
+++ b/packages/gocad/src/evo/data_converters/gocad/importer/__init__.py
@@ -10,6 +10,6 @@
 #  limitations under the License.
 
 from evo.data_converters.gocad.importer.gocad_reader import GocadDataFileIOError, GocadInvalidDataError
-from evo.data_converters.gocad.importer.gocad_to_evo import convert_gocad
+from evo.data_converters.gocad.importer.gocad_to_evo import convert_gocad, get_gocad_grids
 
-__all__ = ["GocadDataFileIOError", "GocadInvalidDataError", "convert_gocad"]
+__all__ = ["GocadDataFileIOError", "GocadInvalidDataError", "convert_gocad", "get_gocad_grids"]

--- a/packages/gocad/src/evo/data_converters/gocad/importer/gocad_to_evo.py
+++ b/packages/gocad/src/evo/data_converters/gocad/importer/gocad_to_evo.py
@@ -15,6 +15,7 @@ from evo_schemas.components import BaseSpatialDataProperties_V1_0_1
 
 import evo.logging
 from evo.data_converters.common import (
+    BaseGridData,
     EvoWorkspaceMetadata,
     create_evo_object_service_and_data_client,
     publish_geoscience_objects,
@@ -26,6 +27,18 @@ logger = evo.logging.getLogger("data_converters")
 
 if TYPE_CHECKING:
     from evo.notebooks import ServiceManagerWidget
+
+
+def get_gocad_grids(filepath: str) -> tuple[str, BaseGridData]:
+    """Extract grid data from a GOCAD file without converting to Geoscience Objects.
+    :param filepath: Path to the GOCAD file.
+    :return: A tuple of (name, BaseGridData).
+    :raise GocadDataFileIOError: If failed to open GOCAD file
+    :raise GocadInvalidDataError: If an error was detected in the GOCAD file.
+    :raise UnsupportedRotation: If the GOCAD file contains inverted or skew rotation.
+    """
+
+    return utils.get_grids_from_gocad(filepath=filepath)
 
 
 def convert_gocad(
@@ -56,9 +69,9 @@ def convert_gocad(
 
     :raise MissingConnectionDetailsError: If no connections details could be derived.
     :raise ConflictingConnectionDetailsError: If both evo_workspace_metadata and service_manager_widget present.
-    :raise GocadDataFileIOError: If failed to open Gocad file
-    :raise GocadInvalidDataError: If an error was detected in the Gocad file.
-    :raise UnsupportedRotation: If the Gocan file contains inverted or skew rotation.
+    :raise GocadDataFileIOError: If failed to open GOCAD file
+    :raise GocadInvalidDataError: If an error was detected in the GOCAD file.
+    :raise UnsupportedRotation: If the GOCAD file contains inverted or skew rotation.
     """
 
     publish_objects = True

--- a/packages/gocad/src/evo/data_converters/gocad/importer/utils.py
+++ b/packages/gocad/src/evo/data_converters/gocad/importer/utils.py
@@ -10,7 +10,7 @@
 #  limitations under the License.
 
 import os
-from typing import Optional
+from typing import Any, Optional
 
 import numpy
 import pyarrow as pa
@@ -22,7 +22,7 @@ from evo_schemas.elements import FloatArray1_V1_0_1
 from evo_schemas.objects import Regular3DGrid_V1_2_0
 from scipy.spatial.transform import Rotation
 
-from evo.data_converters.common import crs_from_epsg_code
+from evo.data_converters.common import crs_from_epsg_code, RegularGridData
 from evo.data_converters.common.utils import check_rotation_matrix, convert_rotation, grid_bounding_box
 from evo.data_converters.gocad.importer.gocad_reader import import_gocad_voxel
 from evo.objects.utils.data import ObjectDataClient
@@ -47,10 +47,17 @@ def _create_continuous_attributes(
     return cell_attributes
 
 
-def get_geoscience_object_from_gocad(
-    data_client: ObjectDataClient, filepath: str, epsg_code: int, tags: Optional[dict[str, str]] = None
-) -> Regular3DGrid_V1_2_0:
-    vo_result, label_to_values_and_filter, final_grid = import_gocad_voxel(filepath)
+def _create_continuous_attributes_for_grid(label_to_values_and_filter: dict) -> list[dict[str, Any]]:
+    cell_attributes = []
+    for name, values_and_filter in label_to_values_and_filter.items():
+        values, filter = values_and_filter
+        table = pa.table({"values": values})
+        nans = numpy.unique(values[filter])
+        cell_attributes.append(dict(name=name, values=table, nans=nans.tolist()))  # TODO do we need these?
+    return cell_attributes
+
+
+def _extract_gocad_data(vo_result, final_grid):
     tx_rotation, tx_offset = vo_result.transform
     base_point, spacing, grid_size = final_grid
     rotation = tx_rotation if tx_rotation is not None else numpy.identity(3)
@@ -63,6 +70,39 @@ def get_geoscience_object_from_gocad(
         rotated_origin += tx_offset
 
     bbox = grid_bounding_box(rotated_origin, rotation, numpy.array(spacing) * numpy.array(grid_size))
+    return origin, rotated_origin, grid_size, spacing, bbox, rotation
+
+
+def get_grids_from_gocad(filepath: str) -> tuple[str, RegularGridData]:
+    vo_result, label_to_values_and_filter, final_grid = import_gocad_voxel(filepath)
+
+    origin, rotated_origin, grid_size, spacing, bbox, rotation = _extract_gocad_data(vo_result, final_grid)
+
+    cell_attributes = _create_continuous_attributes_for_grid(label_to_values_and_filter)
+    rotation_object = convert_rotation(Rotation.from_matrix(rotation.T))
+
+    return (
+        vo_result.header["name"],
+        RegularGridData(
+            origin=rotated_origin.tolist(),
+            size=grid_size.tolist(),
+            cell_size=spacing.tolist(),
+            rotation=[rotation_object.dip_azimuth, rotation_object.dip, rotation_object.pitch],
+            bounding_box=[bbox.min_x, bbox.max_x, bbox.min_y, bbox.max_y, bbox.min_z, bbox.max_z],
+            mask=None,
+            cell_attributes=cell_attributes,
+            vertex_attributes=None,
+        ),
+    )
+
+
+def get_geoscience_object_from_gocad(
+    data_client: ObjectDataClient, filepath: str, epsg_code: int, tags: Optional[dict[str, str]] = None
+) -> Regular3DGrid_V1_2_0:
+    vo_result, label_to_values_and_filter, final_grid = import_gocad_voxel(filepath)
+
+    origin, rotated_origin, grid_size, spacing, bbox, rotation = _extract_gocad_data(vo_result, final_grid)
+
     cell_attributes = _create_continuous_attributes(data_client, label_to_values_and_filter)
 
     object_tags = {}

--- a/packages/gocad/tests/importers/test_gocad_to_grid.py
+++ b/packages/gocad/tests/importers/test_gocad_to_grid.py
@@ -1,0 +1,51 @@
+#  Copyright © 2025 Bentley Systems, Incorporated
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from pathlib import Path
+
+import pytest
+
+from evo.data_converters.common import RegularGridData
+from evo.data_converters.common.utils import UnsupportedRotation
+from evo.data_converters.gocad.importer import GocadInvalidDataError, get_gocad_grids
+
+this_dir = Path(__file__).parent
+
+
+def test_failed_to_read_file() -> None:
+    file_name = this_dir / "data" / "fake_file.go"
+    with pytest.raises(GocadInvalidDataError):
+        get_gocad_grids(str(file_name))
+
+
+@pytest.mark.parametrize("test_file, exc_message", [("non_orthogonal.vo", "skew"), ("inverted.vo", "invert")])
+def test_unsupported_rotation(caplog: pytest.LogCaptureFixture, test_file: str, exc_message: str) -> None:
+    file_name = this_dir / "data" / test_file
+    with pytest.raises(UnsupportedRotation) as excinfo:
+        get_gocad_grids(str(file_name))
+
+    assert str(excinfo.value) == exc_message
+
+
+def test_gocad_grid_data() -> None:
+    file_name = this_dir / "data" / "3D_grid_GOCAD.vo"
+    name, grid_data = get_gocad_grids(filepath=str(file_name))
+    assert isinstance(grid_data, RegularGridData)
+
+    assert name == "3D_grid_GOCAD"
+    assert grid_data.size == [17, 10, 3]
+    assert grid_data.origin == [716375.0, 6530775.0, 375.0]
+    assert grid_data.cell_size == [50.0, 50.0, 50.0]
+    assert len(grid_data.cell_attributes) == 1
+    assert grid_data.cell_attributes[0]["name"] == "Data"
+    assert len(grid_data.cell_attributes[0]["values"][0]) == 510
+    assert grid_data.bounding_box == [716375.0, 717225.0, 6530775.0, 6531275.0, 375.0, 525.0]
+    assert grid_data.vertex_attributes is None


### PR DESCRIPTION
This allows conversion of GOCAD data to an intermediary format that has not been converted into Evo Geoscience Objects.

<!--
Thank you for taking the time to make a pull request.

Please review our [contribution guide](https://github.com/SeequentEvo/evo-data-converters/blob/main/CONTRIBUTING.md) and our
[code of conduct](https://github.com/SeequentEvo/evo-data-converters/blob/main/CONTRIBUTING.md) before opening your first
pull request.
-->

## Description

<!-- Describe your proposed changes in detail -->

## Checklist

- [x] I have read the contributing guide and the code of conduct
