### PR TITLE
Allow extracting UBC data as non-geoscience objects

### DIFF
--- a/packages/ubc/src/evo/data_converters/ubc/importer/__init__.py
+++ b/packages/ubc/src/evo/data_converters/ubc/importer/__init__.py
@@ -12,4 +12,4 @@
 from evo.data_converters.ubc.importer.ubc_reader import UBCFileIOError, UBCInvalidDataError, UBCOOMError
 from evo.data_converters.ubc.importer.ubc_to_evo import convert_ubc
 
-__all__ = ["UBCFileIOError", "UBCInvalidDataError", "UBCOOMError", "convert_ubc"]
+__all__ = ["UBCFileIOError", "UBCInvalidDataError", "UBCOOMError", "convert_ubc", "get_ubc_grids"]

--- a/packages/ubc/src/evo/data_converters/ubc/importer/ubc_to_evo.py
+++ b/packages/ubc/src/evo/data_converters/ubc/importer/ubc_to_evo.py
@@ -15,6 +15,7 @@ from evo_schemas.components import BaseSpatialDataProperties_V1_0_1
 
 import evo.logging
 from evo.data_converters.common import (
+    BaseGridData,
     EvoWorkspaceMetadata,
     create_evo_object_service_and_data_client,
     publish_geoscience_objects,
@@ -26,6 +27,19 @@ logger = evo.logging.getLogger("data_converters")
 
 if TYPE_CHECKING:
     from evo.notebooks import ServiceManagerWidget
+
+
+def get_ubc_grids(files_path: list[str]) -> list[tuple[str, BaseGridData]]:
+    """Extract grid data from a UBC file without converting to Geoscience Objects.
+
+    :param files_path: list of paths to the UBC .msh/.nev files.
+    :return: list of (name, grid data objects).
+
+    :raise UBCFileIOError: If failed to read UBC file.
+    :raise UBCInvalidDataError: If an error was detected within the UBC file.
+    :raise UBCOOMError: If out of memory error occurred while handling the UBC file.
+    """
+    return utils.get_grid_data(files_path)
 
 
 def convert_ubc(

--- a/packages/ubc/tests/importers/test_ubc_utils.py
+++ b/packages/ubc/tests/importers/test_ubc_utils.py
@@ -16,7 +16,8 @@ import numpy as np
 import pytest
 from evo_schemas import Tensor3DGrid_V1_2_0
 
-from evo.data_converters.ubc.importer.utils import get_geoscience_object_from_ubc
+from evo.data_converters.common import TensorGridData
+from evo.data_converters.ubc.importer.utils import get_geoscience_object_from_ubc, get_grid_data
 from evo.objects.utils.data import ObjectDataClient
 
 
@@ -88,6 +89,30 @@ def test_get_geoscience_object_from_ubc_success(
         result.bounding_box.max_z,
     )
     assert bbox == (1.0, 4.0, 2.0, 6.0, 3.0, 8.0)
+
+
+def test_get_grid_data_from_ubc_success(mock_mesh_importer: MagicMock, mock_property_importer: MagicMock) -> None:
+    files_path = ["dummy_file.msh", "dummy_values.txt"]
+
+    mock_mesh_importer.return_value.execute.return_value = (
+        np.array([1.0, 2.0, 3.0]),
+        [np.array([3.0]), np.array([4.0]), np.array([5.0])],
+        [3, 4, 5],
+    )
+    mock_property_importer.return_value.execute.return_value = np.array([1.0])
+
+    name, grid_data = get_grid_data(files_path)
+
+    assert isinstance(grid_data, TensorGridData)
+    assert grid_data.size == [3, 4, 5]
+    assert grid_data.origin == [1.0, 2.0, 3.0]
+    assert len(grid_data.cell_attributes) == 1
+    assert grid_data.cell_attributes[0]["name"] == "dummy_values"
+    assert grid_data.cell_sizes_x == [3.0]
+    assert grid_data.cell_sizes_y == [4.0]
+    assert grid_data.cell_sizes_z == [5.0]
+    assert grid_data.bounding_box == [1.0, 4.0, 2.0, 6.0, 3.0, 8.0]
+    np.testing.assert_array_equal(grid_data.rotation, [0.0, 0.0, 0.0])
 
 
 def test_get_geoscience_object_from_ubc_no_mesh_file(mock_data_client: MagicMock) -> None:


### PR DESCRIPTION
This allows conversion of UBC data to an intermediary format that has not been converted into Evo Geoscience Objects.

<!--
Thank you for taking the time to make a pull request.

Please review our [contribution guide](https://github.com/SeequentEvo/evo-data-converters/blob/main/CONTRIBUTING.md) and our
[code of conduct](https://github.com/SeequentEvo/evo-data-converters/blob/main/CONTRIBUTING.md) before opening your first
pull request.
-->

## Description

<!-- Describe your proposed changes in detail -->

## Checklist

- [x] I have read the contributing guide and the code of conduct
