### PR TITLE
Avoid publishing int attributes with NaN, and harden type cast

### DIFF
--- a/packages/duf/pyproject.toml
+++ b/packages/duf/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "evo-data-converters-duf"
 description = "Python data converters for Deswik DUF to Evo geoscience objects"
-version = "0.1.8"
+version = "0.1.9"
 requires-python = ">=3.10"
 license-files = ["LICENSE.md"]
 dynamic = ["readme"]

--- a/packages/duf/tests/conftest.py
+++ b/packages/duf/tests/conftest.py
@@ -42,6 +42,10 @@ class TestDataClient:
         chunks_parquet_file = path.join(str(self.data_client.cache_location), table.data)
         return pq.read_table(chunks_parquet_file)
 
+    def load_columns(self, table) -> list:
+        table_pd = self.load_table(table).to_pandas()
+        return [table_pd[col].to_numpy() for col in table_pd.columns]
+
     def load_category(self, attr_go):
         lookup_df = self.load_table(attr_go.table).to_pandas().set_index("key")
         values_df = self.load_table(attr_go.values).to_pandas()

--- a/packages/duf/tests/importer/conftest.py
+++ b/packages/duf/tests/importer/conftest.py
@@ -115,3 +115,25 @@ def id_attribute_path():
 def id_attribute(id_attribute_path):
     with DUFCollectorContext(id_attribute_path) as context:
         yield context.collector
+
+
+@pytest.fixture(scope="session")
+def missing_ints_path():
+    return str((Path(__file__).parent.parent / "data" / "missing_ints.duf").resolve())
+
+
+@pytest.fixture(scope="session")
+def missing_ints(missing_ints_path):
+    with DUFCollectorContext(missing_ints_path) as context:
+        yield context.collector
+
+
+@pytest.fixture(scope="session")
+def mismatching_type_desc_and_values_path():
+    return str((Path(__file__).parent.parent / "data" / "mismatching_type_desc_and_values.duf").resolve())
+
+
+@pytest.fixture(scope="session")
+def mismatching_type_desc_and_values(mismatching_type_desc_and_values_path):
+    with DUFCollectorContext(mismatching_type_desc_and_values_path) as context:
+        yield context.collector

--- a/uv.lock
+++ b/uv.lock
@@ -811,7 +811,7 @@ dev = [
 
 [[package]]
 name = "evo-data-converters-duf"
-version = "0.1.8"
+version = "0.1.9"
 source = { editable = "packages/duf" }
 dependencies = [
     { name = "evo-data-converters-common" },


### PR DESCRIPTION


<!--
Thank you for taking the time to make a pull request.

Please review our [contribution guide](https://github.com/SeequentEvo/evo-data-converters/blob/main/CONTRIBUTING.md) and our
[code of conduct](https://github.com/SeequentEvo/evo-data-converters/blob/main/CONTRIBUTING.md) before opening your first
pull request.
-->

## Description

This commit has 1 workaround and 1 bugfix

Workaround:

When publishing to Evo, missing values in integer attributes get published as NaN. Leapfrog does hot handle integer attributes, so converte these attributes to double before publishing.

Bugfix:

It's possible for a Deswik Entity's attributes to have values that don't have the type indicated by their layer's type spec. This was previously causing an uncaught exception. Now this kind of attribute value will be treated as if it were missing.

## Checklist

- [x] I have read the contributing guide and the code of conduct
