### PR TITLE
Make convert_duf async

### DIFF
--- a/packages/common/src/evo/data_converters/common/__init__.py
+++ b/packages/common/src/evo/data_converters/common/__init__.py
@@ -13,7 +13,7 @@ from .blockmodel_client import BlockSyncClient
 from .grid_data import BaseGridData, RegularGridData, TensorGridData
 from .crs import crs_from_epsg_code, crs_from_ogc_wkt, crs_unspecified, crs_from_any
 from .evo_client import EvoObjectMetadata, EvoWorkspaceMetadata, create_evo_object_service_and_data_client
-from .publish import publish_geoscience_objects
+from .publish import publish_geoscience_objects, publish_geoscience_objects_sync
 
 __all__ = [
     "create_evo_object_service_and_data_client",
@@ -21,6 +21,7 @@ __all__ = [
     "BlockSyncClient",
     "EvoObjectMetadata",
     "publish_geoscience_objects",
+    "publish_geoscience_objects_sync",
     "BaseGridData",
     "RegularGridData",
     "TensorGridData",

--- a/packages/common/src/evo/data_converters/common/publish.py
+++ b/packages/common/src/evo/data_converters/common/publish.py
@@ -25,7 +25,7 @@ from .generate_paths import generate_paths
 logger = evo.logging.getLogger("data_converters")
 
 
-def publish_geoscience_objects(
+def publish_geoscience_objects_sync(
     object_models: list[BaseSpatialDataProperties_V1_0_1],
     object_service_client: ObjectAPIClient,
     data_client: ObjectDataClient,
@@ -44,6 +44,30 @@ def publish_geoscience_objects(
     for obj, obj_path in zip(object_models, paths):
         object_metadata = asyncio.run(
             publish_geoscience_object(obj_path, obj, object_service_client, data_client, overwrite_existing_objects)
+        )
+        logger.debug(f"Got object metadata: {object_metadata}")
+        objects_metadata.append(object_metadata)
+
+    return objects_metadata
+
+
+async def publish_geoscience_objects(
+    object_models: list[BaseSpatialDataProperties_V1_0_1],
+    object_service_client: ObjectAPIClient,
+    data_client: ObjectDataClient,
+    path_prefix: str = "",
+    overwrite_existing_objects: bool = False,
+) -> list[ObjectMetadata]:
+    """
+    Publishes a list of Geoscience Objects.
+    """
+    objects_metadata = []
+    paths = generate_paths(object_models, path_prefix)
+
+    logger.debug(f"Preparing to publish {len(object_models)} objects to paths: {paths}")
+    for obj, obj_path in zip(object_models, paths):
+        object_metadata = await publish_geoscience_object(
+            obj_path, obj, object_service_client, data_client, overwrite_existing_objects
         )
         logger.debug(f"Got object metadata: {object_metadata}")
         objects_metadata.append(object_metadata)

--- a/packages/common/tests/test_publish_geoscience_objects.py
+++ b/packages/common/tests/test_publish_geoscience_objects.py
@@ -13,7 +13,7 @@ from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, MagicMock, Mock, call, patch
 
 from evo.common.exceptions import NotFoundException
-from evo.data_converters.common.publish import publish_geoscience_object, publish_geoscience_objects
+from evo.data_converters.common.publish import publish_geoscience_object, publish_geoscience_objects_sync
 
 
 class TestPublishGeoscienceObjects(IsolatedAsyncioTestCase):
@@ -35,7 +35,7 @@ class TestPublishGeoscienceObjects(IsolatedAsyncioTestCase):
         mock_publish_geoscience_object.return_value = expected_metadata
         mock_generate_paths.return_value = ["test/mock_1.json", "test/mock_2.json"]
 
-        objects_metadata = publish_geoscience_objects(
+        objects_metadata = publish_geoscience_objects_sync(
             object_models=self.test_objects,
             object_service_client=self.mock_object_service_client,
             data_client=self.mock_data_client,
@@ -62,7 +62,7 @@ class TestPublishGeoscienceObjects(IsolatedAsyncioTestCase):
 
     @patch("evo.data_converters.common.publish.publish_geoscience_object")
     def test_publish_geoscience_objects_empty_list(self, mock_publish_geoscience_object: AsyncMock) -> None:
-        objects_metadata = publish_geoscience_objects([], self.mock_object_service_client, self.mock_data_client)
+        objects_metadata = publish_geoscience_objects_sync([], self.mock_object_service_client, self.mock_data_client)
 
         self.assertEqual(objects_metadata, [])
         mock_publish_geoscience_object.assert_not_called()

--- a/packages/duf/pyproject.toml
+++ b/packages/duf/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "evo-data-converters-duf"
 description = "Python data converters for Deswik DUF to Evo geoscience objects"
-version = "0.1.9"
+version = "0.2.0"
 requires-python = ">=3.10"
 license-files = ["LICENSE.md"]
 dynamic = ["readme"]

--- a/packages/duf/samples/convert-duf/convert-duf.ipynb
+++ b/packages/duf/samples/convert-duf/convert-duf.ipynb
@@ -61,7 +61,7 @@
     "epsg_code = 32650\n",
     "\n",
     "tags = {\"TagName\": \"Tag value\"}\n",
-    "objects_metadata = convert_duf(\n",
+    "objects_metadata = await convert_duf(\n",
     "    filepath=duf_file,\n",
     "    epsg_code=epsg_code,\n",
     "    service_manager_widget=manager,\n",

--- a/packages/duf/src/evo/data_converters/duf/importer/duf_to_evo.py
+++ b/packages/duf/src/evo/data_converters/duf/importer/duf_to_evo.py
@@ -119,7 +119,7 @@ def _convert_duf_objects(
     return geoscience_objects
 
 
-def convert_duf(
+async def convert_duf(
     filepath: str,
     epsg_code: int,
     evo_workspace_metadata: Optional[EvoWorkspaceMetadata] = None,
@@ -179,7 +179,7 @@ def convert_duf(
     objects_metadata = None
     if publish_objects:
         logger.debug(f"Publishing {len(geoscience_objects)} Geoscience Objects")
-        objects_metadata = publish_geoscience_objects(
+        objects_metadata = await publish_geoscience_objects(
             geoscience_objects, object_service_client, data_client, upload_path, overwrite_existing_objects
         )
 

--- a/packages/duf/tests/importer/test_duf_to_evo.py
+++ b/packages/duf/tests/importer/test_duf_to_evo.py
@@ -16,7 +16,7 @@ import numpy
 import pytest
 from evo_schemas.objects import LineSegments_V2_1_0, TriangleMesh_V2_1_0
 
-from evo.data_converters.duf.importer import convert_duf
+from packages.duf.tests.utils import convert_duf
 
 
 def test_should_log_warnings(evo_metadata, simple_objects_path, caplog: pytest.LogCaptureFixture) -> None:

--- a/packages/duf/tests/utils.py
+++ b/packages/duf/tests/utils.py
@@ -1,0 +1,17 @@
+#  Copyright © 2025 Bentley Systems, Incorporated
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import asyncio
+
+from evo.data_converters.duf.importer import convert_duf as convert
+
+
+def convert_duf(*args, **kwargs):
+    return asyncio.run(convert(*args, **kwargs))

--- a/packages/gocad/src/evo/data_converters/gocad/importer/gocad_to_evo.py
+++ b/packages/gocad/src/evo/data_converters/gocad/importer/gocad_to_evo.py
@@ -17,7 +17,7 @@ import evo.logging
 from evo.data_converters.common import (
     EvoWorkspaceMetadata,
     create_evo_object_service_and_data_client,
-    publish_geoscience_objects,
+    publish_geoscience_objects_sync,
 )
 from evo.data_converters.gocad.importer import utils
 from evo.objects.data import ObjectMetadata
@@ -74,7 +74,7 @@ def convert_gocad(
     objects_metadata = None
     if publish_objects:
         logger.debug("Publishing Geoscience Objects")
-        objects_metadata = publish_geoscience_objects(
+        objects_metadata = publish_geoscience_objects_sync(
             geoscience_objects, object_service_client, data_client, upload_path, overwrite_existing_objects
         )
 

--- a/packages/omf/src/evo/data_converters/omf/importer/omf_to_evo.py
+++ b/packages/omf/src/evo/data_converters/omf/importer/omf_to_evo.py
@@ -19,7 +19,7 @@ import evo.logging
 from evo.data_converters.common import (
     EvoWorkspaceMetadata,
     create_evo_object_service_and_data_client,
-    publish_geoscience_objects,
+    publish_geoscience_objects_sync,
 )
 from evo.data_converters.omf import OMFReaderContext
 from evo.objects.data import ObjectMetadata
@@ -128,7 +128,7 @@ def convert_omf(
     objects_metadata = None
     if publish_objects:
         logger.debug("Publishing Geoscience Objects")
-        objects_metadata = publish_geoscience_objects(
+        objects_metadata = publish_geoscience_objects_sync(
             geoscience_objects, object_service_client, data_client, upload_path, overwrite_existing_objects
         )
 

--- a/packages/omf/tests/blockmodel/test_blockmodel_to_blocksync.py
+++ b/packages/omf/tests/blockmodel/test_blockmodel_to_blocksync.py
@@ -229,7 +229,7 @@ class TestOMFToBlockSyncConverter(TestCase):
             org_id="bf1a040c-8c58-4bc2-bec2-c5ae7de8bd84",
         )
 
-    @patch("evo.data_converters.omf.importer.omf_to_evo.publish_geoscience_objects")
+    @patch("evo.data_converters.omf.importer.omf_to_evo.publish_geoscience_objects_sync")
     @patch.object(BlockSyncClient, "get_auth_header")
     def test_should_convert_blockmodels(
         self, mock_publish_geoscience_objects: MagicMock, mock_get_auth_header: MagicMock

--- a/packages/resqml/src/evo/data_converters/resqml/importer/resqml_to_evo.py
+++ b/packages/resqml/src/evo/data_converters/resqml/importer/resqml_to_evo.py
@@ -26,7 +26,7 @@ import evo.logging
 from evo.data_converters.common import (
     EvoWorkspaceMetadata,
     create_evo_object_service_and_data_client,
-    publish_geoscience_objects,
+    publish_geoscience_objects_sync,
 )
 from evo.data_converters.resqml import convert_size
 from evo.data_converters.resqml.utils import estimate_corner_points_size
@@ -114,7 +114,7 @@ def convert_resqml(
     objects_metadata = None
     if publish_objects:
         logger.debug("Publishing Geoscience Objects")
-        objects_metadata = publish_geoscience_objects(
+        objects_metadata = publish_geoscience_objects_sync(
             geoscience_objects, object_service_client, data_client, upload_path, overwrite_existing_objects
         )
 

--- a/packages/ubc/src/evo/data_converters/ubc/importer/ubc_to_evo.py
+++ b/packages/ubc/src/evo/data_converters/ubc/importer/ubc_to_evo.py
@@ -17,7 +17,7 @@ import evo.logging
 from evo.data_converters.common import (
     EvoWorkspaceMetadata,
     create_evo_object_service_and_data_client,
-    publish_geoscience_objects,
+    publish_geoscience_objects_sync,
 )
 from evo.data_converters.ubc.importer import utils
 from evo.objects.data import ObjectMetadata
@@ -74,7 +74,7 @@ def convert_ubc(
     objects_metadata = None
     if publish_objects:
         logger.debug("Publishing Geoscience Objects")
-        objects_metadata = publish_geoscience_objects(
+        objects_metadata = publish_geoscience_objects_sync(
             geoscience_objects, object_service_client, data_client, upload_path, overwrite_existing_objects
         )
 

--- a/packages/ubc/tests/importers/test_ubc_to_evo.py
+++ b/packages/ubc/tests/importers/test_ubc_to_evo.py
@@ -34,7 +34,7 @@ def test_convert_ubc_success() -> None:
         patch(
             "evo.data_converters.ubc.importer.ubc_to_evo.create_evo_object_service_and_data_client"
         ) as mock_create_client,
-        patch("evo.data_converters.ubc.importer.ubc_to_evo.publish_geoscience_objects") as mock_publish,
+        patch("evo.data_converters.ubc.importer.ubc_to_evo.publish_geoscience_objects_sync") as mock_publish,
         patch(
             "evo.data_converters.ubc.importer.utils.get_geoscience_object_from_ubc", return_value=mock_geoscience_object
         ),

--- a/packages/vtk/src/evo/data_converters/vtk/importer/vtk_to_evo.py
+++ b/packages/vtk/src/evo/data_converters/vtk/importer/vtk_to_evo.py
@@ -22,7 +22,7 @@ from evo.data_converters.common import (
     BaseGridData,
     EvoWorkspaceMetadata,
     create_evo_object_service_and_data_client,
-    publish_geoscience_objects,
+    publish_geoscience_objects_sync,
 )
 from evo.objects.data import ObjectMetadata
 from evo.objects.utils import ObjectDataClient
@@ -179,7 +179,7 @@ def convert_vtk(
     objects_metadata = None
     if publish_objects:
         logger.debug("Publishing Geoscience Objects")
-        objects_metadata = publish_geoscience_objects(
+        objects_metadata = publish_geoscience_objects_sync(
             geoscience_objects, object_service_client, data_client, upload_path, overwrite_existing_objects
         )
 

--- a/uv.lock
+++ b/uv.lock
@@ -764,7 +764,7 @@ dev = [
 
 [[package]]
 name = "evo-data-converters-common"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/common" }
 dependencies = [
     { name = "aiohttp" },
@@ -811,7 +811,7 @@ dev = [
 
 [[package]]
 name = "evo-data-converters-duf"
-version = "0.1.9"
+version = "0.2.0"
 source = { editable = "packages/duf" }
 dependencies = [
     { name = "evo-data-converters-common" },


### PR DESCRIPTION
## Description

The conversion makes use of an async function from the Evo SDK for publishing objects. Making the conversion async avoids having to create or re-enter an event loop for the publishing.

Jupyter notebooks are running their own event loop, and asyncio blocks re-entering or creating a new event loop on the same thread. The library `nest_asyncio` was an attempt to circumvent that restriction, but that was causing problems.

This commit prepares for other converters becoming async.

## Checklist

- [x] I have read the contributing guide and the code of conduct
