### PR TITLE
Add pre-commit and test for invalid uv.lock sources

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,11 @@
 repos:
+  - repo: local
+    hooks:
+      - id: check-uv-lock-sources
+        name: Check uv.lock sources
+        entry: python scripts/check_uv_lock_sources.py
+        language: python
+        files: (^|/)uv\.lock$
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: v0.9.1 # keep in sync with pyproject.toml
     hooks:

--- a/scripts/check_uv_lock_sources.py
+++ b/scripts/check_uv_lock_sources.py
@@ -1,0 +1,65 @@
+#  Copyright © 2026 Bentley Systems, Incorporated
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+PYPI = "https://pypi.org/simple"
+
+_SOURCE = re.compile(
+    r"""
+    ^\s*
+    source \s* = \s*
+    \{ \s* (?P<body>.*?) \s* }
+    \s*$
+""",
+    re.VERBOSE,
+)
+
+_ALLOWED = re.compile(
+    r"""
+    registry \s* = \s* "(?P<registry>[^"]+)"
+    | (?:editable|virtual|git) \s* = \s* "[^"]+"
+""",
+    re.VERBOSE,
+)
+
+
+def validate_lock_file(lockfile: Path) -> bool:
+    for line in lockfile.read_text(encoding="utf-8").splitlines():
+        match = _SOURCE.match(line)
+        if match is None:
+            continue
+        body = match.group("body").strip()
+        allowed_match = _ALLOWED.fullmatch(body)
+        if allowed_match and (allowed_match.group("registry") is None or allowed_match.group("registry") == PYPI):
+            continue
+        return False
+    return True
+
+
+def main() -> int:
+    lockfiles = sorted(Path.cwd().rglob("uv.lock"))
+    bad_files = [f for f in lockfiles if not validate_lock_file(f)]
+    if bad_files:
+        print("uv.lock validation failed:", file=sys.stderr)
+        for f in bad_files:
+            print(f"  {f}", file=sys.stderr)
+        return 1
+    print(f"Validated {len(lockfiles)} uv.lock file(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_uv_lock_sources.py
+++ b/tests/test_uv_lock_sources.py
@@ -1,0 +1,95 @@
+#  Copyright © 2026 Bentley Systems, Incorporated
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "check_uv_lock_sources.py"
+
+spec = importlib.util.spec_from_file_location("check_uv_lock_sources", SCRIPT_PATH)
+if spec is None or spec.loader is None:
+    raise RuntimeError(f"Unable to load validator module from {SCRIPT_PATH}")
+
+validator = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = validator
+spec.loader.exec_module(validator)
+
+
+def test_repo_uv_lock_files_use_only_default_pypi_sources() -> None:
+    lockfiles = validator.find_uv_lock_files(REPO_ROOT)
+
+    assert lockfiles == [REPO_ROOT / "code-samples" / "uv.lock", REPO_ROOT / "uv.lock"]
+
+    for lockfile in lockfiles:
+        assert validator.validate_lock_file(lockfile) is True
+
+
+def test_custom_registry_source_is_rejected(tmp_path: Path) -> None:
+    lockfile = tmp_path / "uv.lock"
+    lockfile.write_text(
+        """
+version = 1
+
+[[package]]
+name = "demo"
+version = "1.0.0"
+source = { registry = "https://packages.example.com/simple" }
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert validator.validate_lock_file(lockfile) is False
+
+
+def test_editable_and_virtual_sources_are_allowed(tmp_path: Path) -> None:
+    lockfile = tmp_path / "uv.lock"
+    lockfile.write_text(
+        """
+version = 1
+
+[[package]]
+name = "workspace-member"
+version = "0.1.0"
+source = { editable = "packages/member" }
+
+[[package]]
+name = "virtual-member"
+version = "0.1.0"
+source = { virtual = "." }
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert validator.validate_lock_file(lockfile) is True
+
+
+def test_unsupported_non_registry_source_is_rejected(tmp_path: Path) -> None:
+    lockfile = tmp_path / "uv.lock"
+    lockfile.write_text(
+        """
+version = 1
+
+[[package]]
+name = "demo"
+version = "1.0.0"
+source = { git = "https://example.com/repo.git" }
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert validator.validate_lock_file(lockfile) is False

--- a/uv.lock
+++ b/uv.lock
@@ -912,7 +912,7 @@ dev = [{ name = "pytest" }]
 
 [[package]]
 name = "evo-data-converters-image"
-version = "0.1.1"
+version = "0.1.4"
 source = { editable = "packages/image" }
 dependencies = [
     { name = "evo-data-converters-common" },


### PR DESCRIPTION
## Description

Added a pre-commit and test to check for invalid uv.lock sources (i.e. sources that are not `https://pypi.org/simple`).

## Checklist

- [x] I have read the contributing guide and the code of conduct
