### PR TITLE
CLGPHX-192 - Update to make shx and dbf filepaths explicit

### DIFF
--- a/packages/shp/pyproject.toml
+++ b/packages/shp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evo-data-converters-shp"
-version = "0.1.3"
+version = "0.1.4"
 description = "Python data converters for ESRI shapefiles to Evo geoscience objects."
 readme = "README.md"
 authors = [

--- a/packages/shp/src/evo/data_converters/shp/importer/implementation/shp_parser.py
+++ b/packages/shp/src/evo/data_converters/shp/importer/implementation/shp_parser.py
@@ -28,31 +28,41 @@ class ShpParser:
     def __init__(
         self,
         path: str,
+        shx_path: str,
+        dbf_path: str,
         data_client: ObjectDataClient,
         crs: Crs_V1_0_1,
         tags: dict[str, str] = None,
-        shx_path: str | None = None,
-        dbf_path: str | None = None,
+        cpg_path: str | None = None,
+        sbn_path: str | None = None,
+        sbx_path: str | None = None,
+        xml_path: str | None = None,
     ):
         """
         Initialize the shapefile to triangle mesh converter.
 
-        :param path: The path to the input shapefile. Can be just the basename, a path to any component file, or
-        a path to a zip file containing the shapefile.
+        :param path: The path to the .shp geometry file.
+        :param shx_path: The path to the .shx spatial index file.
+        :param dbf_path: The path to the .dbf attribute file.
         :param data_client: Object data client for uploading parquet files (real or stub).
         :param crs: Coordiante reference system to use for the file. Cannot be None, but can be "unspecified".
         :param tags: (Optional) Dict of tags to add to the Geoscience Object(s).
-        :param shx_path: (Optional) Explicit path to the .shx index file. If not provided, pyshp will
-        attempt to auto-discover it relative to the .shp file.
-        :param dbf_path: (Optional) Explicit path to the .dbf attribute file. If not provided, pyshp will
-        attempt to auto-discover it relative to the .shp file.
+        :param cpg_path: (Optional) Path to the .cpg code page file. If provided, the encoding
+        specified in the file will be used when reading the .dbf attribute data.
+        :param sbn_path: (Optional) Path to the .sbn spatial index file. Accepted but not currently used.
+        :param sbx_path: (Optional) Path to the .sbx spatial index file. Accepted but not currently used.
+        :param xml_path: (Optional) Path to the .shp.xml metadata file. Accepted but not currently used.
         """
         self.path = path
+        self.shx_path = shx_path
+        self.dbf_path = dbf_path
         self.data_client = data_client
         self.crs = crs
         self.tags = tags
-        self.shx_path = shx_path
-        self.dbf_path = dbf_path
+        self.cpg_path = cpg_path
+        self.sbn_path = sbn_path
+        self.sbx_path = sbx_path
+        self.xml_path = xml_path
 
     def parse_shp(self) -> TriangleMesh_V2_2_0:
         """
@@ -62,12 +72,12 @@ class ShpParser:
 
         :raise InvalidSHPError: If the input shapefile is invalid or cannot be parsed
         """
-        if self.shx_path is not None or self.dbf_path is not None:
-            reader = shapefile.Reader(shp=self.path, shx=self.shx_path, dbf=self.dbf_path)
-        else:
-            reader = shapefile.Reader(self.path)
+        reader_kwargs: dict = {"shp": self.path, "shx": self.shx_path, "dbf": self.dbf_path}
+        if self.cpg_path is not None:
+            with open(self.cpg_path) as f:
+                reader_kwargs["encoding"] = f.read().strip()
 
-        with reader as sf:
+        with shapefile.Reader(**reader_kwargs) as sf:
             if sf.shapeType != shapefile.MULTIPATCH:
                 raise InvalidSHPError(
                     "Provided shapefile is not multipatch. Only multipatch shapefiles without rings are supported."

--- a/packages/shp/src/evo/data_converters/shp/importer/implementation/shp_parser.py
+++ b/packages/shp/src/evo/data_converters/shp/importer/implementation/shp_parser.py
@@ -25,7 +25,15 @@ class ShpParser:
     Currently only supports multipatch files without rings.
     """
 
-    def __init__(self, path: str, data_client: ObjectDataClient, crs: Crs_V1_0_1, tags: dict[str, str] = None):
+    def __init__(
+        self,
+        path: str,
+        data_client: ObjectDataClient,
+        crs: Crs_V1_0_1,
+        tags: dict[str, str] = None,
+        shx_path: str | None = None,
+        dbf_path: str | None = None,
+    ):
         """
         Initialize the shapefile to triangle mesh converter.
 
@@ -33,12 +41,18 @@ class ShpParser:
         a path to a zip file containing the shapefile.
         :param data_client: Object data client for uploading parquet files (real or stub).
         :param crs: Coordiante reference system to use for the file. Cannot be None, but can be "unspecified".
-        :param tags: (Optional) Dict of tags to add to the Geoscience Object(s)."
+        :param tags: (Optional) Dict of tags to add to the Geoscience Object(s).
+        :param shx_path: (Optional) Explicit path to the .shx index file. If not provided, pyshp will
+        attempt to auto-discover it relative to the .shp file.
+        :param dbf_path: (Optional) Explicit path to the .dbf attribute file. If not provided, pyshp will
+        attempt to auto-discover it relative to the .shp file.
         """
         self.path = path
         self.data_client = data_client
         self.crs = crs
         self.tags = tags
+        self.shx_path = shx_path
+        self.dbf_path = dbf_path
 
     def parse_shp(self) -> TriangleMesh_V2_2_0:
         """
@@ -48,7 +62,12 @@ class ShpParser:
 
         :raise InvalidSHPError: If the input shapefile is invalid or cannot be parsed
         """
-        with shapefile.Reader(self.path) as sf:
+        if self.shx_path is not None or self.dbf_path is not None:
+            reader = shapefile.Reader(shp=self.path, shx=self.shx_path, dbf=self.dbf_path)
+        else:
+            reader = shapefile.Reader(self.path)
+
+        with reader as sf:
             if sf.shapeType != shapefile.MULTIPATCH:
                 raise InvalidSHPError(
                     "Provided shapefile is not multipatch. Only multipatch shapefiles without rings are supported."

--- a/packages/shp/src/evo/data_converters/shp/importer/shp_to_evo.py
+++ b/packages/shp/src/evo/data_converters/shp/importer/shp_to_evo.py
@@ -29,6 +29,8 @@ if TYPE_CHECKING:
 def convert_shp(
     filepath: str,
     filepath_prj: Optional[str] = None,
+    filepath_shx: Optional[str] = None,
+    filepath_dbf: Optional[str] = None,
     evo_workspace_metadata: Optional[EvoWorkspaceMetadata] = None,
     service_manager_widget: Optional["ServiceManagerWidget"] = None,
     tags: Optional[dict[str, str]] = None,
@@ -41,7 +43,12 @@ def convert_shp(
 
     :param filepath: Path to the base filename of the shapefile, any of the component files (.shp, .shx, or .dbf),
      or a zip file containing the shapefile.
-    :param epsg_code: The EPSG code to use when creating a Coordinate Reference System object.
+    :param filepath_prj: (Optional) Explicit path to the .prj projection file. If not provided,
+     the CRS will be set to "unspecified".
+    :param filepath_shx: (Optional) Explicit path to the .shx spatial index file. If not provided,
+     pyshp will attempt to auto-discover it relative to the .shp file.
+    :param filepath_dbf: (Optional) Explicit path to the .dbf attribute file. If not provided,
+     pyshp will attempt to auto-discover it relative to the .shp file.
     :param evo_workspace_metadata: (Optional) Evo workspace metadata.
     :param service_manager_widget: (Optional) Service Manager Widget for use in jupyter notebooks.
     :param tags: (Optional) Dict of tags to add to the Geoscience Object(s).
@@ -49,7 +56,7 @@ def convert_shp(
     :param publish_objects: (Optional) Set False to prevent publishing and instead return Geoscience models.
     :param overwrite_existing_objects: (Optional) Set True to overwrite any existing object at the destiation path.
 
-    :return: list[ObjectMetadata] if publish_objects is true, otherwise list[Regular2DGrid]
+    :return: list[ObjectMetadata] if publish_objects is true, otherwise list[TriangleMesh_V2_2_0]
 
     :raise MissingConnectionDetailsError: If no connections details could be derived.
     :raise ConflictingConnectionDetailsError: If both evo_workspace_metadata and service_manager_widget present.
@@ -76,7 +83,9 @@ def convert_shp(
 
     crs = prj_to_crs(filepath_prj)
 
-    parser = ShpParser(path=filepath, data_client=data_client, crs=crs, tags=full_tags)
+    parser = ShpParser(
+        path=filepath, data_client=data_client, crs=crs, tags=full_tags, shx_path=filepath_shx, dbf_path=filepath_dbf
+    )
     mesh = parser.parse_shp()
 
     geoscience_objects.append(mesh)

--- a/packages/shp/src/evo/data_converters/shp/importer/shp_to_evo.py
+++ b/packages/shp/src/evo/data_converters/shp/importer/shp_to_evo.py
@@ -28,9 +28,13 @@ if TYPE_CHECKING:
 
 def convert_shp(
     filepath: str,
+    filepath_shx: str,
+    filepath_dbf: str,
     filepath_prj: Optional[str] = None,
-    filepath_shx: Optional[str] = None,
-    filepath_dbf: Optional[str] = None,
+    filepath_cpg: Optional[str] = None,
+    filepath_sbn: Optional[str] = None,
+    filepath_sbx: Optional[str] = None,
+    filepath_xml: Optional[str] = None,
     evo_workspace_metadata: Optional[EvoWorkspaceMetadata] = None,
     service_manager_widget: Optional["ServiceManagerWidget"] = None,
     tags: Optional[dict[str, str]] = None,
@@ -41,14 +45,16 @@ def convert_shp(
     """
     Convert an ESRI shapefile (.shp, .shx, and .dbf) to a triangle-mesh geoscience object.
 
-    :param filepath: Path to the base filename of the shapefile, any of the component files (.shp, .shx, or .dbf),
-     or a zip file containing the shapefile.
-    :param filepath_prj: (Optional) Explicit path to the .prj projection file. If not provided,
+    :param filepath: Path to the .shp geometry file.
+    :param filepath_shx: Path to the .shx spatial index file.
+    :param filepath_dbf: Path to the .dbf attribute file.
+    :param filepath_prj: (Optional) Path to the .prj projection file. If not provided,
      the CRS will be set to "unspecified".
-    :param filepath_shx: (Optional) Explicit path to the .shx spatial index file. If not provided,
-     pyshp will attempt to auto-discover it relative to the .shp file.
-    :param filepath_dbf: (Optional) Explicit path to the .dbf attribute file. If not provided,
-     pyshp will attempt to auto-discover it relative to the .shp file.
+    :param filepath_cpg: (Optional) Path to the .cpg code page file. If provided, the encoding
+     specified in the file will be used when reading the .dbf attribute data.
+    :param filepath_sbn: (Optional) Path to the .sbn spatial index file. Accepted but not currently used.
+    :param filepath_sbx: (Optional) Path to the .sbx spatial index file. Accepted but not currently used.
+    :param filepath_xml: (Optional) Path to the .shp.xml metadata file. Accepted but not currently used.
     :param evo_workspace_metadata: (Optional) Evo workspace metadata.
     :param service_manager_widget: (Optional) Service Manager Widget for use in jupyter notebooks.
     :param tags: (Optional) Dict of tags to add to the Geoscience Object(s).
@@ -84,7 +90,16 @@ def convert_shp(
     crs = prj_to_crs(filepath_prj)
 
     parser = ShpParser(
-        path=filepath, data_client=data_client, crs=crs, tags=full_tags, shx_path=filepath_shx, dbf_path=filepath_dbf
+        path=filepath,
+        shx_path=filepath_shx,
+        dbf_path=filepath_dbf,
+        data_client=data_client,
+        crs=crs,
+        tags=full_tags,
+        cpg_path=filepath_cpg,
+        sbn_path=filepath_sbn,
+        sbx_path=filepath_sbx,
+        xml_path=filepath_xml,
     )
     mesh = parser.parse_shp()
 

--- a/packages/shp/tests/importers/test_shp_to_triangle_mesh.py
+++ b/packages/shp/tests/importers/test_shp_to_triangle_mesh.py
@@ -110,7 +110,12 @@ def parquet_path(tmp_path: Path) -> Path:
 def test_convert_basic_shp(sample_shp: tuple[Path, int, int, int, int], parquet_path: Path):
     path, expected_fields, expected_shape_num, expected_triangle_num, expected_vertex_num = sample_shp
     triangle_meshes = convert_shp(
-        path, None, upload_path=parquet_path, publish_objects=False, overwrite_existing_objects=True
+        filepath=path,
+        filepath_shx=path.with_suffix(".shx"),
+        filepath_dbf=path.with_suffix(".dbf"),
+        upload_path=parquet_path,
+        publish_objects=False,
+        overwrite_existing_objects=True,
     )
 
     assert len(triangle_meshes) == 1
@@ -152,7 +157,13 @@ def test_custom_tags(sample_shp: Path, parquet_path: Path):
     expected_tags = {"Stage": "Experimental", "InputType": "SHP", **(tags)}
 
     triangle_meshes = convert_shp(
-        path, None, tags=tags, upload_path=parquet_path, publish_objects=False, overwrite_existing_objects=True
+        filepath=path,
+        filepath_shx=path.with_suffix(".shx"),
+        filepath_dbf=path.with_suffix(".dbf"),
+        tags=tags,
+        upload_path=parquet_path,
+        publish_objects=False,
+        overwrite_existing_objects=True,
     )
 
     assert len(triangle_meshes) == 1
@@ -167,7 +178,13 @@ def test_prj(sample_shp: Path, prj: Path, parquet_path: Path):
     prj_file, expected_prj = prj
 
     triangle_meshes = convert_shp(
-        path, filepath_prj=prj_file, upload_path=parquet_path, publish_objects=False, overwrite_existing_objects=True
+        filepath=path,
+        filepath_shx=path.with_suffix(".shx"),
+        filepath_dbf=path.with_suffix(".dbf"),
+        filepath_prj=prj_file,
+        upload_path=parquet_path,
+        publish_objects=False,
+        overwrite_existing_objects=True,
     )
 
     assert len(triangle_meshes) == 1
@@ -181,7 +198,12 @@ def test_parquet_output(sample_shp: Path, parquet_path: Path):
     path, _, _, _, _ = sample_shp
 
     triangle_meshes = convert_shp(
-        path, None, upload_path=parquet_path, publish_objects=False, overwrite_existing_objects=True
+        filepath=path,
+        filepath_shx=path.with_suffix(".shx"),
+        filepath_dbf=path.with_suffix(".dbf"),
+        upload_path=parquet_path,
+        publish_objects=False,
+        overwrite_existing_objects=True,
     )
 
     assert len(triangle_meshes) == 1


### PR DESCRIPTION
<!--
Thank you for taking the time to make a pull request.

Please review our [contribution guide](https://github.com/SeequentEvo/evo-data-converters/blob/main/CONTRIBUTING.md) and our
[code of conduct](https://github.com/SeequentEvo/evo-data-converters/blob/main/CONTRIBUTING.md) before opening your first
pull request.
-->

## Description

Updated the Shapefile Converter to now accept explicit paths for the companion files in the shapefile format (ie. shx and dbf).

## Checklist

- [x] I have read the contributing guide and the code of conduct
