### PR TITLE
Bump version of data converters for WKT CRS support

### DIFF
--- a/packages/duf/pyproject.toml
+++ b/packages/duf/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "evo-data-converters-duf"
 description = "Python data converters for Deswik DUF to Evo geoscience objects"
-version = "0.2.2"
+version = "0.3.0"
 requires-python = ">=3.10"
 license-files = ["LICENSE.md"]
 dynamic = ["readme"]

--- a/packages/gocad/pyproject.toml
+++ b/packages/gocad/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "evo-data-converters-gocad"
 description = "Python data converters for GOCAD to Evo geoscience objects"
-version = "0.1.4"
+version = "0.2.0"
 requires-python = ">=3.10"
 license-files = ["LICENSE.md"]
 dynamic = ["readme"]

--- a/packages/obj/pyproject.toml
+++ b/packages/obj/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "evo-data-converters-obj"
 description = "Python data converters for Wavefront Technologies OBJ/MTL file to Evo geoscience objects"
-version = "0.0.3"
+version = "0.1.0"
 requires-python = ">=3.10"
 license-files = ["LICENSE.md"]
 dynamic = ["readme"]

--- a/packages/omf/pyproject.toml
+++ b/packages/omf/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "evo-data-converters-omf"
 description = "Python data converters for OMF to Evo geoscience objects"
-version = "0.1.6"
+version = "0.2.0"
 requires-python = ">=3.10"
 license-files = ["LICENSE.md"]
 dynamic = ["readme"]

--- a/packages/resqml/pyproject.toml
+++ b/packages/resqml/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "evo-data-converters-resqml"
 description = "Python data converters for RESQML to Evo geoscience objects"
-version = "0.1.4"
+version = "0.2.0"
 requires-python = ">=3.10"
 license-files = ["LICENSE.md"]
 dynamic = ["readme"]

--- a/packages/ubc/pyproject.toml
+++ b/packages/ubc/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "evo-data-converters-ubc"
 description = "Python data converters for UBC to Evo geoscience objects"
-version = "0.1.4"
+version = "0.2.0"
 requires-python = ">=3.10"
 license-files = ["LICENSE.md"]
 dynamic = ["readme"]

--- a/packages/vtk/pyproject.toml
+++ b/packages/vtk/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "evo-data-converters-vtk"
 description = "Python data converters for VTK to Evo geoscience objects"
-version = "0.1.4"
+version = "0.2.0"
 requires-python = ">=3.10"
 license-files = ["LICENSE.md"]
 dynamic = ["readme"]

--- a/uv.lock
+++ b/uv.lock
@@ -864,7 +864,7 @@ dev = [
 
 [[package]]
 name = "evo-data-converters-duf"
-version = "0.2.2"
+version = "0.3.0"
 source = { editable = "packages/duf" }
 dependencies = [
     { name = "evo-data-converters-common" },
@@ -893,7 +893,7 @@ dev = [
 
 [[package]]
 name = "evo-data-converters-gocad"
-version = "0.1.4"
+version = "0.2.0"
 source = { editable = "packages/gocad" }
 dependencies = [
     { name = "evo-data-converters-common" },
@@ -951,7 +951,7 @@ dev = [
 
 [[package]]
 name = "evo-data-converters-obj"
-version = "0.0.3"
+version = "0.1.0"
 source = { editable = "packages/obj" }
 dependencies = [
     { name = "evo-data-converters-common" },
@@ -980,7 +980,7 @@ dev = [
 
 [[package]]
 name = "evo-data-converters-omf"
-version = "0.1.6"
+version = "0.2.0"
 source = { editable = "packages/omf" }
 dependencies = [
     { name = "evo-data-converters-common" },
@@ -1011,7 +1011,7 @@ dev = [
 
 [[package]]
 name = "evo-data-converters-resqml"
-version = "0.1.4"
+version = "0.2.0"
 source = { editable = "packages/resqml" }
 dependencies = [
     { name = "evo-data-converters-common" },
@@ -1038,7 +1038,7 @@ dev = [
 
 [[package]]
 name = "evo-data-converters-shp"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "packages/shp" }
 dependencies = [
     { name = "evo-data-converters-common" },
@@ -1065,7 +1065,7 @@ dev = [{ name = "pytest" }]
 
 [[package]]
 name = "evo-data-converters-ubc"
-version = "0.1.4"
+version = "0.2.0"
 source = { editable = "packages/ubc" }
 dependencies = [
     { name = "evo-data-converters-common" },
@@ -1084,7 +1084,7 @@ dev = [{ name = "pytest" }]
 
 [[package]]
 name = "evo-data-converters-vtk"
-version = "0.1.4"
+version = "0.2.0"
 source = { editable = "packages/vtk" }
 dependencies = [
     { name = "evo-data-converters-common" },
@@ -1107,7 +1107,7 @@ dev = [{ name = "pytest" }]
 
 [[package]]
 name = "evo-data-converters-xyz"
-version = "0.0.1"
+version = "0.0.2"
 source = { editable = "packages/xyz" }
 dependencies = [
     { name = "evo-data-converters-common" },


### PR DESCRIPTION
<!--
Thank you for taking the time to make a pull request.

Please review our [contribution guide](https://github.com/SeequentEvo/evo-data-converters/blob/main/CONTRIBUTING.md) and our
[code of conduct](https://github.com/SeequentEvo/evo-data-converters/blob/main/CONTRIBUTING.md) before opening your first
pull request.
-->

## Description

<!-- Describe your proposed changes in detail -->
Bump versions of data converters that was affected by the new support for WKT2 coordinate reference systems. Forgot to do it as part of https://github.com/SeequentEvo/evo-data-converters/pull/211.

## Checklist

- [x] I have read the contributing guide and the code of conduct
