### PR TITLE
Incorrect automatic assignment of WGS84 (EPSG 4326) to im…

### DIFF
--- a/packages/image/code-samples/convert-image/QUICKSTART.md
+++ b/packages/image/code-samples/convert-image/QUICKSTART.md
@@ -81,7 +81,8 @@ This creates:
 
 ## Schema Output
 
-The converter creates JSON matching your example (grayscale shown below):
+The converter creates JSON matching your example (grayscale shown below).
+When no CRS is provided, the coordinate_reference_system is set to "unspecified" to preserve data integrity:
 
 ```json
 {
@@ -91,7 +92,7 @@ The converter creates JSON matching your example (grayscale shown below):
   "origin": [572565.0, 6839415.0, 1000.0],
   "size": [128, 106],
   "cell_size": [30.0, 30.0],
-  "coordinate_reference_system": {"epsg_code": 4326},
+  "coordinate_reference_system": "unspecified",
   "rotation": {"dip": 0.0, "dip_azimuth": 0.0, "pitch": 0.0},
   "bounding_box": {
     "min_x": 572565.0,

--- a/packages/image/code-samples/convert-image/WORKFLOW.md
+++ b/packages/image/code-samples/convert-image/WORKFLOW.md
@@ -55,7 +55,7 @@ INPUT: Image File (JPEG, PNG, TIFF, BMP, GIF, etc.)
 │       grayscale: {attribute_type:"scalar", name:"2d-grid-data-..."},   │
 │       color:     {attribute_type:"color",  name:"2d-grid-data-color"}   │
 │     ],                                                                   │
-│     "coordinate_reference_system": {...},  ← EPSG provided or 4326     │
+│     "coordinate_reference_system": {...},  ← EPSG provided or "unspecified" if not provided │
 │     "tags": {...}                      ← Optional metadata             │
 │   }                                                                     │
 └─────────────────────────────────────────────────────────────────────────┘

--- a/packages/image/pyproject.toml
+++ b/packages/image/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evo-data-converters-image"
-version = "0.1.5"
+version = "0.1.6"
 description = "Image data converter for Evo (supports JPEG, PNG, TIFF, etc.)"
 license-files = ["LICENSE.md"]
 dynamic = ["readme"]

--- a/packages/image/src/evo/data_converters/image/image_to_grid.py
+++ b/packages/image/src/evo/data_converters/image/image_to_grid.py
@@ -35,6 +35,7 @@ from evo.data_converters.common import (
     EvoWorkspaceMetadata,
     create_evo_object_service_and_data_client,
     publish_geoscience_objects_sync,
+    crs_unspecified,
 )
 
 from evo.objects.utils.data import ObjectDataClient
@@ -343,6 +344,9 @@ class ImageGridConverter:
                     crs = coordinate_reference_system["ogc_wkt"]  # WKT string
             else:
                 crs = coordinate_reference_system
+        else:
+            # No CRS provided: use unspecified to preserve data integrity
+            crs = crs_unspecified()
 
         # Assemble Regular 2D Grid object
         grid = Regular2DGrid_V1_3_0(
@@ -351,9 +355,7 @@ class ImageGridConverter:
             description=grid_description,
             tags=tags,
             bounding_box=bbox,
-            coordinate_reference_system=crs
-            if crs is not None
-            else Crs_V1_0_1_EpsgCode(epsg_code=4326),  # default WGS84
+            coordinate_reference_system=crs,
             origin=grid_origin,
             size=[width, height],
             cell_size=grid_cell_size,

--- a/packages/image/tests/importers/test_image_to_grid.py
+++ b/packages/image/tests/importers/test_image_to_grid.py
@@ -205,6 +205,17 @@ def test_tags_and_crs(sample_image: Tuple[Path, int, int], mock_data_client: _Mo
     assert grid.coordinate_reference_system.epsg_code == 32618
 
 
+def test_no_crs_when_not_provided(sample_image: Tuple[Path, int, int], mock_data_client: _MockDataClient):
+    """When no CRS is provided, coordinate_reference_system should be 'unspecified'."""
+    image_path, _, _ = sample_image
+
+    converter = ImageGridConverter(mock_data_client, output_parquet=False)
+    grid = converter.convert(str(image_path))
+
+    # Image without an explicitly defined coordinate system should be marked as unspecified
+    assert grid.coordinate_reference_system == "unspecified"
+
+
 def test_parquet_file_output(sample_image: Tuple[Path, int, int], mock_data_client: _MockDataClient, tmp_path: Path):
     """When output_parquet=True, a local parquet file is written with hash filename."""
     image_path, _, _ = sample_image

--- a/uv.lock
+++ b/uv.lock
@@ -912,7 +912,7 @@ dev = [{ name = "pytest" }]
 
 [[package]]
 name = "evo-data-converters-image"
-version = "0.1.5"
+version = "0.1.6"
 source = { editable = "packages/image" }
 dependencies = [
     { name = "evo-data-converters-common" },


### PR DESCRIPTION
…ages lacking a defined coordinate system.

fix: use 'unspecified' CRS instead of auto-assigning WGS84 to images Prevents data integrity issues when images lack defined coordinate systems.

<!--
Thank you for taking the time to make a pull request.

Please review our [contribution guide](https://github.com/SeequentEvo/evo-data-converters/blob/main/CONTRIBUTING.md) and our
[code of conduct](https://github.com/SeequentEvo/evo-data-converters/blob/main/CONTRIBUTING.md) before opening your first
pull request.
-->

## Description

<!-- Describe your proposed changes in detail -->

## Checklist

- [x] I have read the contributing guide and the code of conduct
