### PR TITLE
Guard against missing attribute

### DIFF
--- a/packages/duf/pyproject.toml
+++ b/packages/duf/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "evo-data-converters-duf"
 description = "Python data converters for Deswik DUF to Evo geoscience objects"
-version = "0.3.0"
+version = "0.3.1"
 requires-python = ">=3.10"
 license-files = ["LICENSE.md"]
 dynamic = ["readme"]

--- a/packages/duf/src/evo/data_converters/duf/xprops.py
+++ b/packages/duf/src/evo/data_converters/duf/xprops.py
@@ -85,8 +85,11 @@ def get_xprops_value(xproperties: dw.XProperties, key: str):
     if not found:
         return None
 
-    value = value.Value[0].Value
-    return value
+    value_list = value.Value
+    if value_list is None or len(value_list) == 0:
+        return None
+
+    return value_list[0].Value
 
 
 def _cast_to_csharp(value, csharp_type: str):


### PR DESCRIPTION

## Description

A DUF project was encountered where the attribute was missing in an unfamiliar way. The "value list" was an empty list, instead of being length 1.

The DUF "xproperties" can be used for a variety of reasons and can also be written by 3rd party tools. It is prudent to simply harden this code path.

## Checklist

- [x] I have read the contributing guide and the code of conduct
