### PR TITLE
Make scripts run on the package directory they are run in

### DIFF
--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -78,15 +78,19 @@ uv sync
 ### Developer tasks (`uv run`)
 
 Common developer tasks are exposed as scripts on the `evo-data-converters-common` package. Run
-them from `packages/common`:
+lint and test commands from the converter package you want to check; run `create-converter` from
+`packages/common`:
 
 ```shell
-cd packages/common
+cd packages/<converter>
 
-uv run lint            # ruff check + format --check over the repo
-uv run lint-fix        # ruff check --fix + format over the repo
-uv run test            # sync and run the tests for every package
-uv run test-<type>     # sync and run the tests for a single package, e.g. test-xyz
+uv run lint            # ruff check + format --check for this package
+uv run lint-fix        # ruff check --fix + format for this package
+uv run test            # sync and run the tests for this package
+uv run test-<type>     # sync and run the tests for a named package, e.g. test-xyz
+
+cd ../common
+
 uv run create-converter  # scaffold a new converter (see below)
 ```
 
@@ -244,6 +248,7 @@ from evo.data_converters.common import (
 # depending on the type of file
 from yourfileparsermodule import yourfileparser
 
+
 # Define the main convert function
 def convert_yourfiletype(
     filepath: str,
@@ -251,7 +256,7 @@ def convert_yourfiletype(
     evo_workspace_metadata: Optional[EvoWorkspaceMetadata] = None,
     service_manager_widget: Optional["ServiceManagerWidget"] = None,
     upload_path: str = "",
-    overwrite_existing_objects: bool = False
+    overwrite_existing_objects: bool = False,
 ) -> list[ObjectMetadata]:
     geoscience_objects = []
 
@@ -281,7 +286,6 @@ def convert_yourfiletype(
 
     # Return the publishing response
     return objects_metadata
-
 ```
 
 **Note:** this example only returns the `ObjectMetadata`, and will publish immediately. Refer to the existing

--- a/packages/common/src/evo/data_converters/common/_dev_tasks.py
+++ b/packages/common/src/evo/data_converters/common/_dev_tasks.py
@@ -48,17 +48,17 @@ def _run(command: list[str], cwd: Path) -> None:
 
 
 def lint() -> None:
-    """Check formatting and lint rules across the repository."""
-    root = _repo_root()
-    _run(["ruff", "check", str(root)], cwd=root)
-    _run(["ruff", "format", "--check", str(root)], cwd=root)
+    """Check formatting and lint rules in the invoking package."""
+    package_dir = Path.cwd()
+    _run(["ruff", "check", str(package_dir)], cwd=package_dir)
+    _run(["ruff", "format", "--check", str(package_dir)], cwd=package_dir)
 
 
 def lint_fix() -> None:
-    """Apply lint and formatting fixes across the repository."""
-    root = _repo_root()
-    _run(["ruff", "check", "--fix", str(root)], cwd=root)
-    _run(["ruff", "format", str(root)], cwd=root)
+    """Apply lint and formatting fixes in the invoking package."""
+    package_dir = Path.cwd()
+    _run(["ruff", "check", "--fix", str(package_dir)], cwd=package_dir)
+    _run(["ruff", "format", str(package_dir)], cwd=package_dir)
 
 
 def create_converter() -> None:
@@ -80,13 +80,12 @@ def _test_package(package: str) -> int:
 
 
 def test_all() -> None:
-    """Run the tests for every package under packages/."""
-    packages_dir = _repo_root() / "packages"
-    for package_dir in sorted(p for p in packages_dir.iterdir() if p.is_dir()):
-        returncode = _test_package(package_dir.name)
-        # Exit code 5 means "no tests collected", which is not a failure here.
-        if returncode not in (0, 5):
-            sys.exit(returncode)
+    """Run the tests for the package from which the command is invoked."""
+    package_dir = Path.cwd()
+    returncode = _test_package(package_dir.name)
+    # Exit code 5 means "no tests collected", which is not a failure here.
+    if returncode not in (0, 5):
+        sys.exit(returncode)
 
 
 def test_package() -> None:

--- a/packages/gocad/pyproject.toml
+++ b/packages/gocad/pyproject.toml
@@ -18,6 +18,9 @@ Documentation = "https://developer.seequent.com/"
 [dependency-groups]
 dev = ["pytest"]
 
+[tool.uv.sources]
+evo-data-converters-common = { path = "../common", editable = true }
+
 [build-system]
 requires = ["hatchling", "hatch-fancy-pypi-readme"]
 build-backend = "hatchling.build"

--- a/packages/image/code-samples/convert-image/QUICKSTART.md
+++ b/packages/image/code-samples/convert-image/QUICKSTART.md
@@ -31,9 +31,7 @@ from evo.data_converters.image import convert_image_to_grid
 from evo.notebooks import ServiceManagerWidget
 
 # Authenticate
-manager = await ServiceManagerWidget.with_auth_code(
-    client_id="your-client-id"
-).login()
+manager = await ServiceManagerWidget.with_auth_code(client_id="your-client-id").login()
 
 # Convert and publish
 results = convert_image_to_grid(
@@ -41,7 +39,7 @@ results = convert_image_to_grid(
     origin=[572565.0, 6839415.0, 1000.0],
     cell_size=[30.0, 30.0],
     service_manager_widget=manager,
-    upload_path="grids/image_imports"
+    upload_path="grids/image_imports",
 )
 ```
 

--- a/packages/image/code-samples/convert-image/README.md
+++ b/packages/image/code-samples/convert-image/README.md
@@ -53,16 +53,14 @@ from evo.data_converters.image import convert_image_to_grid
 from evo.notebooks import ServiceManagerWidget
 
 # Authenticate
-manager = await ServiceManagerWidget.with_auth_code(
-    client_id="your-client-id"
-).login()
+manager = await ServiceManagerWidget.with_auth_code(client_id="your-client-id").login()
 
 # Convert and publish
 results = convert_image_to_grid(
     image_path="path/to/image.jpg",
     service_manager_widget=manager,
     upload_path="grids/image_imports",
-    tags={"Source": "Jupyter Notebook"}
+    tags={"Source": "Jupyter Notebook"},
 )
 
 print(f"Published: {results[0].name}")
@@ -84,7 +82,7 @@ results = convert_image_to_grid(
     service_manager_widget=manager,
     upload_path="grids",
     publish_objects=True,
-    overwrite_existing_objects=False
+    overwrite_existing_objects=False,
 )
 ```
 
@@ -99,11 +97,7 @@ data_client = ObjectDataClient(...)
 converter = ImageGridConverter(data_client, output_parquet=True)
 
 # Convert to grid object
-grid = converter.convert(
-    image_path="image.jpg",
-    origin=[0, 0, 0],
-    cell_size=[1, 1]
-)
+grid = converter.convert(image_path="image.jpg", origin=[0, 0, 0], cell_size=[1, 1])
 
 # Access grid properties
 print(f"Size: {grid.size}")  # [width, height]
@@ -183,9 +177,7 @@ crs = {"epsg_code": 32618}  # UTM Zone 18N
 
 ### WKT String
 ```python
-crs = {
-    "ogc_wkt": 'PROJCS["NAD27 / UTM zone 18N",...]'
-}
+crs = {"ogc_wkt": 'PROJCS["NAD27 / UTM zone 18N",...]'}
 ```
 
 ## Example Output
@@ -262,9 +254,9 @@ Enable parquet file output for debugging:
 from evo.data_converters.image.importer.image_to_grid import ImageGridConverter
 
 converter = ImageGridConverter(
-    data_client, 
+    data_client,
     output_dir="./debug_parquet",
-    output_parquet=True  # Write files to disk
+    output_parquet=True,  # Write files to disk
 )
 ```
 

--- a/packages/omf/README.md
+++ b/packages/omf/README.md
@@ -183,7 +183,7 @@ async with hub_connector:
         epsg_code=epsg_code,
         object_service_client=service_client,
         tags=tags,
-        upload_path="path/to/my/object"
+        upload_path="path/to/my/object",
     )
 
     print("These objects have now been published:")
@@ -210,10 +210,7 @@ from evo.data_converters.common import EvoObjectMetadata
 from evo.data_converters.omf.exporter import export_omf
 
 objects = []
-objects.append(
-    EvoObjectMetadata(
-        object_id=UUID("<object_id>"),
-        version_id="<version_id>"))
+objects.append(EvoObjectMetadata(object_id=UUID("<object_id>"), version_id="<version_id>"))
 
 output_dir = "data/output"
 os.makedirs(output_dir, exist_ok=True)


### PR DESCRIPTION
<!--
Thank you for taking the time to make a pull request.

Please review our [contribution guide](https://github.com/SeequentEvo/evo-data-converters/blob/main/CONTRIBUTING.md) and our
[code of conduct](https://github.com/SeequentEvo/evo-data-converters/blob/main/CONTRIBUTING.md) before opening your first
pull request.
-->

## Description

<!-- Describe your proposed changes in detail -->
This was previously running lint and test on all packages, but realistically you would only want to run it on the package you are developing. The `gocad` package was missing a tools line to make the commands for it work and also there are a few lint fixes

## Checklist

- [x] I have read the contributing guide and the code of conduct
