### PR TITLE
Failing test fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ __pycache__/
 .Python
 build/
 develop-eggs/
-dist/
+**/dist/
 downloads/
 eggs/
 .eggs/
@@ -136,7 +136,7 @@ query_results.parquet
 .cache_ggshield
 
 # Object data client caches
-data/cache
+**/data/cache
 
 # Development tools
 .vscode/

--- a/packages/shp/tests/importers/test_mesh_builder.py
+++ b/packages/shp/tests/importers/test_mesh_builder.py
@@ -146,6 +146,7 @@ def shapefile_with_point_data(tmp_path: Path) -> shapefile.Reader:
 def test_add_triangle_strip(triangle_strip: tuple[shapefile.Reader, int, int, int], data_client: LocalDataClient):
     reader, expected_field_num, expected_triangle_num, expected_vertex_num = triangle_strip
     fields = reader.fields[1:]
+    expected_shape_num = reader.numShapes
     mesh_builder = MeshBuilder(data_client=data_client, fields=fields)
 
     for sr in reader.iterShapeRecords():
@@ -153,7 +154,7 @@ def test_add_triangle_strip(triangle_strip: tuple[shapefile.Reader, int, int, in
 
     mesh = mesh_builder.build()
 
-    assert mesh.parts.chunks.length == reader.numShapes
+    assert mesh.parts.chunks.length == expected_shape_num
     assert len(mesh.parts.attributes) == expected_field_num
     assert mesh.triangles.vertices.length == expected_vertex_num
     assert mesh.triangles.vertices.attributes is None
@@ -172,6 +173,7 @@ def test_add_triangle_fan(triangle_fan: tuple[shapefile.Reader, int, int, int], 
     reader, expected_field_num, expected_triangle_num, expected_vertex_num = triangle_fan
     # Skip DeletionFlag field
     fields = reader.fields[1:]
+    expected_shape_num = reader.numShapes
     mesh_builder = MeshBuilder(data_client=data_client, fields=fields)
 
     for sr in reader.iterShapeRecords():
@@ -179,7 +181,7 @@ def test_add_triangle_fan(triangle_fan: tuple[shapefile.Reader, int, int, int], 
 
     mesh = mesh_builder.build()
 
-    assert mesh.parts.chunks.length == reader.numShapes
+    assert mesh.parts.chunks.length == expected_shape_num
     assert len(mesh.parts.attributes) == expected_field_num
     assert mesh.triangles.vertices.length == expected_vertex_num
     assert mesh.triangles.vertices.attributes is None

--- a/packages/vtk/src/evo/data_converters/vtk/importer/_utils.py
+++ b/packages/vtk/src/evo/data_converters/vtk/importer/_utils.py
@@ -74,17 +74,17 @@ def is_float_array(array: vtk.vtkAbstractArray) -> bool:
 
 
 def is_integer_array(array: vtk.vtkAbstractArray) -> bool:
-    return array.GetDataType() in [
-        vtk.VTK_SIGNED_CHAR,
-        vtk.VTK_UNSIGNED_CHAR,
-        vtk.VTK_SHORT,
-        vtk.VTK_UNSIGNED_SHORT,
-        vtk.VTK_INT,
-        vtk.VTK_UNSIGNED_INT,
-        vtk.VTK_LONG,
-        vtk.VTK_UNSIGNED_LONG,
-        vtk.VTK_LONG_LONG,
-    ]
+    if array.GetDataType() == vtk.VTK_STRING:
+        return False
+    return vtk_to_numpy(array).dtype in {
+        np.dtype(np.int8),
+        np.dtype(np.uint8),
+        np.dtype(np.int16),
+        np.dtype(np.uint16),
+        np.dtype(np.int32),
+        np.dtype(np.uint32),
+        np.dtype(np.int64),
+    }
 
 
 def is_string_array(array: vtk.vtkAbstractArray) -> bool:

--- a/packages/vtk/tests/importers/test_vtk_unstructured_grid_to_evo.py
+++ b/packages/vtk/tests/importers/test_vtk_unstructured_grid_to_evo.py
@@ -33,6 +33,7 @@ from evo.data_converters.vtk.importer.vtk_unstructured_grid_to_evo import conver
 def _remove_unused_points(unstructured_grid: vtk.vtkUnstructuredGrid) -> vtk.vtkUnstructuredGrid:
     clean_filter = vtk.vtkRemoveUnusedPoints()
     clean_filter.SetInputData(unstructured_grid)
+    clean_filter.SetGenerateOriginalPointIds(False)
     clean_filter.Update()
     return clean_filter.GetOutput()
 


### PR DESCRIPTION
<!--
Thank you for taking the time to make a pull request.

Please review our [contribution guide](https://github.com/SeequentEvo/evo-data-converters/blob/main/CONTRIBUTING.md) and our
[code of conduct](https://github.com/SeequentEvo/evo-data-converters/blob/main/CONTRIBUTING.md) before opening your first
pull request.
-->

## Description

<!-- Describe your proposed changes in detail -->
I noticed the tests for `vtk` and `shp` are failing, the `vtk` failures are because the datatypes have changed, and as we don't commit the `uv.lock` files, we are getting `vtk 9.7.0`.

We can think about whether we want to bring the `uv.lock` files back, but this should fix it for the current failures and future versions of `vtk`

## Checklist

- [x] I have read the contributing guide and the code of conduct
